### PR TITLE
Remove file checking from ResourceCaches.java

### DIFF
--- a/zweb/src/org/zkoss/web/util/resource/ResourceCaches.java
+++ b/zweb/src/org/zkoss/web/util/resource/ResourceCaches.java
@@ -117,8 +117,7 @@ public class ResourceCaches {
 			final String flnm = ctx.getRealPath(path);
 			if (flnm != null) {
 				final File file = new File(flnm);
-				if (file.exists())
-					return cache.get(new ResourceInfo(path, file, extra));
+				return cache.get(new ResourceInfo(path, file, extra));
 			}
 		}
 


### PR DESCRIPTION
Hi the ZK team,

Could you please verify this change?

I have found that a ContentLoader is responsible for checking the existence of the File, so this check in ResourceCaches is somehow redundant. Also, removing this line can help the ContentLoader to load file from the different location.
