### PR TITLE
Bug fixed ZK-2158: Tab can be click on blank area next to last tab (IE9 ...

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -70,6 +70,7 @@ ZK 7.0.1
   ZK-2128: Frozen Tree - cells disappearing after replacing the columns twice
   ZK-2146: NullPointerException in Selectbox after set its model to null
   ZK-2151: Nested listboxes selection issue
+  ZK-2158: Tab can be click on blank area next to last tab (IE9 only)
 
 * Upgrade Notes
   + Rename the implemetation class of label loader from org.zkoss.util.resource.impl.LabelLoader

--- a/zktest/src/archive/test2/B70-ZK-2158.zul
+++ b/zktest/src/archive/test2/B70-ZK-2158.zul
@@ -1,0 +1,19 @@
+<zk>
+	<label multiline="true">
+		1. Select "Tab 2" 
+		2. Move mouse to blank area next to "Tab 2" then click. 
+		3. "Tab 1" should not be selected.
+	</label>
+	<div>
+		<tabbox width="100%">
+			<tabs>
+				<tab label="Tab 1" />
+				<tab label="Tab 2" />
+			</tabs>
+			<tabpanels>
+				<tabpanel>Test 1</tabpanel>
+				<tabpanel>Test 2</tabpanel>
+			</tabpanels>
+		</tabbox>
+	</div>
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -1712,6 +1712,7 @@ B70-ZK-2130.zul=B,E,Frozen,NativeScrollBar
 B70-ZK-2128.zul=A,E,HeadWidget,Auxhead,HDfaker,Frozen,Tree,Treecol
 B70-ZK-2148.zul=A,E,Selectbox,OnSelect,Model,NPE
 B70-ZK-2151.zul=B,E,Tree,Listbox,Checkmark,Nest
+B70-ZK-2158.zul=A,E,Tabbox,IE9,Tab,Tabs
 
 ##
 # Features - 3.0.x version

--- a/zul/src/archive/web/js/zul/tab/less/tabbox.less
+++ b/zul/src/archive/web/js/zul/tab/less/tabbox.less
@@ -463,3 +463,12 @@
 	padding: 5px;
 	zoom: 1;
 }
+
+// ZK-2158: Tab should not be click on blank area next to last tab
+.ie9 .z-tabs {
+    line-height: 1px;
+
+    > .z-tabs-content {
+	    display: inline-block;
+	}
+}


### PR DESCRIPTION
...only)

http://tracker.zkoss.org/browse/ZK-2158
