### PR TITLE
Enables registering concrete richlets instead of their class names

### DIFF
--- a/zk/src/org/zkoss/zk/ui/util/Configuration.java
+++ b/zk/src/org/zkoss/zk/ui/util/Configuration.java
@@ -2228,6 +2228,22 @@ public class Configuration {
 
 		return addRichlet0(name, richletClassName, params);
 	}
+	/** Adds the richlet.
+	 *
+	 * <p>If there was a richlet associated with the same name, the
+	 * the old one will be replaced.
+	 *
+	 * @param name the richlet name
+	 * @param richlet the richlet implemetation.
+	 * @return the previous richlet class or class-name with the specified name,
+	 * or null if no previous richlet.
+	 */
+	public Object addRichlet(String name, Richlet richlet) {
+		if (richlet == null)
+			throw new IllegalArgumentException("richletClassName is required");
+
+		return addRichlet0(name, richlet, null);
+	}
 	private Object addRichlet0(String name, Object richletClass, Map<String, String> params) {
 		final Object o;
 		synchronized (_richlets) {


### PR DESCRIPTION
In that case, the ZK will get the concrete class and it does not have to
construct the new instance.

So, we'd be able to set the richlet's properties before registering it
to the ZK. Now, we have to set all properties in the richlet's
constructor what is not adequate in some cases.
