### PR TITLE
ZK-2276 fixes TreeNodeChildrenList to be compatible with JavaSE 8

### DIFF
--- a/zul/src/org/zkoss/zul/DefaultTreeModel.java
+++ b/zul/src/org/zkoss/zul/DefaultTreeModel.java
@@ -167,13 +167,11 @@ implements Sortable<TreeNode<E>>, java.io.Serializable {
 		}
 	}
 	
-	@SuppressWarnings("rawtypes")
 	private void sort0(TreeNode<E> node, Comparator<TreeNode<E>> cmpr) {
 		if (node.getChildren() == null) return;
-		if (node instanceof DefaultTreeNode)
-			((TreeNodeChildrenList)node.getChildren()).sort(cmpr);
-		else
-			Collections.sort(node.getChildren(), cmpr);
+
+		Collections.sort(node.getChildren(), cmpr);
+
 		for (TreeNode<E> child: node.getChildren())
 			sort0(child, cmpr);
 	}

--- a/zul/src/org/zkoss/zul/DefaultTreeNode.java
+++ b/zul/src/org/zkoss/zul/DefaultTreeNode.java
@@ -286,13 +286,6 @@ Cloneable, java.io.Serializable  {
 			remove(index);
 			return true;
 		}
-
-		/** Used only internally by DefaultTreeModel.sort0(). it won't fire event INTERVAL_ADDED or INTERVAL_REMOVED */
-		// B50-ZK-566: Set sortDirection to treecol will show an error
-		@SuppressWarnings("unchecked")
-		/*package*/ void sort(Comparator cmpr) {
-			Collections.sort(_list, cmpr);
-		}
 	}
 	
 	


### PR DESCRIPTION
http://tracker.zkoss.org/browse/ZK-2276
