### PR TITLE
Bug ZK-2590: Type numpad 1 but combobox selects an item starting with 'A...

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -9,6 +9,7 @@ ZK 7.0.5
   ZK-2548: Initial keyboard selection causes combobox constraint error
   ZK-2553: grid with frozen JS error
   ZK-2595: The nested hflex size is not up to date when the new child added inside a hlayout or vlayout
+  ZK-2590: Type numpad 1 but combobox selects an item starting with 'A'
 
 * Upgrade Notes
 

--- a/zktest/src/archive/test2/B70-ZK-2590.zul
+++ b/zktest/src/archive/test2/B70-ZK-2590.zul
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+B70-ZK-2590.zul
+
+	Purpose:
+		
+	Description:
+		
+	History:
+		Wed, Jan 28, 2015  8:49:32 AM, Created by Chunfu
+
+Copyright (C)  Potix Corporation. All Rights Reserved.
+
+-->
+<zk>
+	<label multiline="true">
+	1. focus on combobox
+	2. press 1 from numpad
+	3. "1A" should be selected
+	</label>
+	<combobox width="150px" readonly="true" >
+		<comboitem label="A1" value="A1" />
+		<comboitem label="B1" value="B1" />
+		<comboitem label="C1" value="C1" />
+		<comboitem label="0A" value="0A" />
+		<comboitem label="1A" value="1A" />
+		<comboitem label="2A" value="2A" />
+	</combobox>
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -1888,6 +1888,7 @@ B70-ZK-2539.zul=A,H,Tree,Paging,Select,VisiableIndex
 B70-ZK-2548.zul=A,E,Combobox,Constraint,onChange,onSelect,Keydown
 B70-ZK-2553.zul=A,E,Grid,Frozen,Column,javascript,error
 B70-ZK-2595.zul=B,H,Layout,Box,Flex
+B70-ZK-2590.zul=A,E,Combobox,Numpad,Keydown
 
 ##
 # Features - 3.0.x version

--- a/zul/src/archive/web/js/zul/inp/Combobox.js
+++ b/zul/src/archive/web/js/zul/inp/Combobox.js
@@ -325,6 +325,9 @@ zul.inp.Combobox = zk.$extends(zul.inp.ComboWidget, {
 				evt.stop();
 				break;
 			default:
+				//B70-ZK-2590: dealing with numpad keyDown, only 0~9
+				if (keyCode >= 96 && keyCode <= 105)
+					keyCode -= 48;
 				var v = String.fromCharCode(keyCode);
 				var sel = this._findItem0(v, true, true, !!this._sel);
 				if (sel)


### PR DESCRIPTION
...'