### PR TITLE
ZK-2627 Text for 2233 message Reload is incorrect in russian localizatio...

### DIFF
--- a/zul/src/archive/metainfo/mesg/msgzul_ru.properties
+++ b/zul/src/archive/metainfo/mesg/msgzul_ru.properties
@@ -73,7 +73,7 @@
 #-=UPLOAD_SUBMIT
 2103=Загрузка
 #-=UPLOAD_BROWSE
-2104=Browse...
+2104=Обзор...
 
 #
 # Messagebox #
@@ -93,7 +93,7 @@
 #-=IGNORE
 2232=Игнорировать
 #-=RELOAD
-2233=Reload
+2233=Перезагрузить
 
 #
 # Paging #


### PR DESCRIPTION
Message with code 2104, 2233 in msgzul_ru.properties is not translated into Russian language
This commit contains porper translation