### PR TITLE
add an improvement : view model can be proxy

### DIFF
--- a/zel/src/org/zkoss/zel/BeanELResolver.java
+++ b/zel/src/org/zkoss/zel/BeanELResolver.java
@@ -567,7 +567,7 @@ public class BeanELResolver extends ELResolver {
 
     private final BeanProperty property(ELContext ctx, Object base,
             Object property) {
-        Class<?> type = base.getClass();
+        Class<?> type = ProxyUtils.getTargetClass(base);
         String prop = property.toString();
 
         BeanProperties props = this.cache.get(type.getName());

--- a/zel/src/org/zkoss/zel/impl/util/ProxyUtils.java
+++ b/zel/src/org/zkoss/zel/impl/util/ProxyUtils.java
@@ -1,0 +1,147 @@
+package org.zkoss.zel.impl.util;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+public final class ProxyUtils {
+
+  /** The CGLIB class separator character "$$" */
+  public static final String CGLIB_CLASS_SEPARATOR = "$$";
+
+  private static List<String> AOP_TYPE_NAME = initAopTypeNameList();
+
+  private static Map<Class<?>, Class<?>> cache = new HashMap<Class<?>, Class<?>>();
+  
+  private static final String ORG_SPRINGFRAMEWORK_AOP_SPRING_PROXY = "org.springframework.aop.SpringProxy";
+
+  public static Class<?> getTargetClass(Object viewModel) {
+
+    Class<?> result = null;
+
+    Class<?> vmClass = viewModel.getClass();
+
+    if (cache.containsKey(vmClass)) {
+
+      result = cache.get(vmClass);
+
+    } else {
+
+      result = findTargetClass(viewModel);
+      cache.put(vmClass, result);
+
+    }
+
+    return result;
+
+  }
+
+  /**
+   * Check whether the specified class is a CGLIB-generated class.
+   * 
+   * @param clazz the class to check
+   */
+  public static boolean isCglibProxyClass(Class<?> clazz) {
+    return clazz != null && isCglibProxyClassName(clazz.getName());
+  }
+
+  /**
+   * Check whether the specified class name is a CGLIB-generated class.
+   * 
+   * @param className the class name to check
+   */
+  public static boolean isCglibProxyClassName(String className) {
+    return className != null && className.contains(CGLIB_CLASS_SEPARATOR);
+  }
+  
+  public static boolean isSpringJdkDynamicProxy(Class<?> vmClass){
+    boolean isSpringProxy = false;
+    Class<?>[] classes = vmClass.getInterfaces();
+    for (Class<?> clazz : classes) {
+      
+      String typeName = clazz.getName();
+      
+      if (ORG_SPRINGFRAMEWORK_AOP_SPRING_PROXY.equals(typeName)) {
+        isSpringProxy = true;
+        break;
+      }
+    }
+    
+    return isSpringProxy && Proxy.isProxyClass(vmClass);
+  }
+
+  private static Class<?> findTargetClass(Object viewModel) {
+
+    Class<?> vmClass = viewModel.getClass();
+    Class<?> result = vmClass;
+
+    try {
+
+      boolean isAopType = false;
+      boolean isSpringProxy = false;
+
+      Class<?>[] classes = vmClass.getInterfaces();
+      for (Class<?> clazz : classes) {
+
+        String typeName = clazz.getName();
+
+        if (ORG_SPRINGFRAMEWORK_AOP_SPRING_PROXY.equals(typeName)) {
+          isSpringProxy = true;
+        }
+
+        if (AOP_TYPE_NAME.contains(typeName)) {
+          isAopType = true;
+        }
+
+        if (isSpringProxy && isAopType) {
+          break;
+        }
+
+      }
+
+      if (isAopType) {
+
+        Method[] methods = vmClass.getDeclaredMethods();
+        for (Method method : methods) {
+
+          if ("getTargetClass".equals(method.getName())) {
+            result = (Class<?>) method.invoke(viewModel);
+            break;
+          }
+
+        }
+
+        if (result == null && isSpringProxy && isCglibProxyClass(vmClass)) {
+          result = vmClass.getSuperclass();
+        }
+
+      }
+
+    } catch (ReflectiveOperationException e) {
+
+      // Silent error
+
+    }
+
+    return result;
+  }
+
+  private static synchronized List<String> initAopTypeNameList() {
+    AOP_TYPE_NAME = new ArrayList<String>();
+    AOP_TYPE_NAME.add("org.springframework.aop.TargetClassAware");
+    AOP_TYPE_NAME.add("org.springframework.aop.framework.Advised");
+    AOP_TYPE_NAME.add("org.springframework.aop.TargetSource");
+    AOP_TYPE_NAME.add(ORG_SPRINGFRAMEWORK_AOP_SPRING_PROXY);
+    AOP_TYPE_NAME.add("org.springframework.cglib.proxy.Factory");
+
+    return AOP_TYPE_NAME;
+  }
+
+  private ProxyUtils() {
+  }
+
+}

--- a/zkbind/src/org/zkoss/bind/impl/AbstractAnnotatedMethodInvoker.java
+++ b/zkbind/src/org/zkoss/bind/impl/AbstractAnnotatedMethodInvoker.java
@@ -33,6 +33,7 @@ import org.zkoss.bind.BindContext;
 import org.zkoss.bind.Binder;
 import org.zkoss.bind.annotation.AfterCompose;
 import org.zkoss.bind.annotation.Init;
+import org.zkoss.zel.impl.util.ProxyUtils;
 import org.zkoss.zk.ui.Component;
 import org.zkoss.zk.ui.Execution;
 import org.zkoss.zk.ui.Executions;
@@ -68,7 +69,7 @@ public abstract class AbstractAnnotatedMethodInvoker<T extends Annotation> {
 		Component rootComp = binder.getView();
 		Object viewModel = rootComp.getAttribute(VM);
 		
-		final Class<?> vmClz = viewModel.getClass();
+		final Class<?> vmClz = ProxyUtils.getTargetClass(viewModel);
 		List<Method> methods = getAnnotateMethods(annoClass, vmClz);
 		if(methods.size()==0) return;//no annotated method
 		

--- a/zkbind/src/org/zkoss/bind/impl/BinderImpl.java
+++ b/zkbind/src/org/zkoss/bind/impl/BinderImpl.java
@@ -88,6 +88,7 @@ import org.zkoss.lang.Objects;
 import org.zkoss.lang.Strings;
 import org.zkoss.lang.reflect.Fields;
 import org.zkoss.util.CacheMap;
+import org.zkoss.zel.impl.util.ProxyUtils;
 import org.zkoss.zk.ui.AbstractComponent;
 import org.zkoss.zk.ui.Component;
 import org.zkoss.zk.ui.Desktop;
@@ -456,7 +457,7 @@ public class BinderImpl implements Binder,BinderCtrl,Serializable{
 		Converter converter = null;
 		if(_hasGetConverterMethod){
 			Object vm = getViewModel();
-			Class<? extends Object> clz = vm.getClass();
+			Class<? extends Object> clz = ProxyUtils.getTargetClass(vm);
 			Method m = null;
 			Object result = null;
 			try {
@@ -498,7 +499,7 @@ public class BinderImpl implements Binder,BinderCtrl,Serializable{
 		Validator validator = null;
 		if(_hasGetValidatorMethod){
 			Object vm = getViewModel();
-			Class<? extends Object> clz = vm.getClass();
+			Class<? extends Object> clz = ProxyUtils.getTargetClass(vm);
 			Method m = null;
 			Object result = null;
 			try {
@@ -1643,7 +1644,7 @@ public class BinderImpl implements Binder,BinderCtrl,Serializable{
 			
 			final Object viewModel = getViewModel();
 			
-			Method method = getCommandMethod(viewModel.getClass(), command, _globalCommandMethodInfoProvider,_globalCommandMethodCache);
+			Method method = getCommandMethod(ProxyUtils.getTargetClass(viewModel), command, _globalCommandMethodInfoProvider,_globalCommandMethodCache);
 			
 			if (method != null) {
 				
@@ -1841,7 +1842,7 @@ public class BinderImpl implements Binder,BinderCtrl,Serializable{
 			
 			final Object viewModel = getViewModel();
 			
-			Method method = getCommandMethod(viewModel.getClass(), command, _commandMethodInfoProvider, _commandMethodCache);
+			Method method = getCommandMethod(ProxyUtils.getTargetClass(viewModel), command, _commandMethodInfoProvider, _commandMethodCache);
 			
 			if (method != null) {
 				

--- a/zkbind/src/org/zkoss/bind/impl/CommandBindingImpl.java
+++ b/zkbind/src/org/zkoss/bind/impl/CommandBindingImpl.java
@@ -21,6 +21,7 @@ import org.zkoss.bind.sys.BindEvaluatorX;
 import org.zkoss.bind.sys.CommandBinding;
 import org.zkoss.lang.Classes;
 import org.zkoss.xel.ExpressionX;
+import org.zkoss.zel.impl.util.ProxyUtils;
 import org.zkoss.zk.ui.Component;
 import org.zkoss.zk.ui.UiException;
 
@@ -56,7 +57,7 @@ public class CommandBindingImpl extends BindingImpl implements CommandBinding {
 		final BindEvaluatorX eval = getBinder().getEvaluatorX();
 		final String methodName = (String) eval.getValue(ctx, comp, getCommand());
 		try {
-			final Method method = Classes.getMethodInPublic(base.getClass(), methodName, new Class[] {Map.class});
+			final Method method = Classes.getMethodInPublic(ProxyUtils.getTargetClass(base), methodName, new Class[] {Map.class});
 			method.invoke(getBinder().getViewModel(), ctx.getAttributes());
 		} catch (Exception e) {
 			throw UiException.Aide.wrap(e);


### PR DESCRIPTION
ProxyUtils : utility class use to access to the target class of a proxy
AbstractAnnotatedMethodInvoker + BinderImpl + CommandBindingImpl : get
the target class
ParamCall + BenELResolver : invoke a method from a proxy
