### PR TITLE
Bug Fix ZK-2906: Escaped characters are not parsed back in ChosenBox …

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -32,6 +32,7 @@ ZK 8.0.1
   ZK-2893: small typo in error message in ConfigParser
   ZK-2917: MVVM relocating components with ViewModels
   ZK-2901: getBoundingClientRect() is slow in ie
+  ZK-2906: Escaped characters are not parsed back in ChosenBox > CreateMessage
 
 * Upgrade Notes
   + In org.zkoss.zul.Chart and org.zkoss.zkmax.zul.Fusionchart, using hflex and vflex will get exception since this version, you should use width and height instead.

--- a/zktest/src/archive/test2/B80-ZK-2906.zul
+++ b/zktest/src/archive/test2/B80-ZK-2906.zul
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+B80-ZK-2906.zul
+
+	Purpose:
+		
+	Description:
+		
+	History:
+		Thu Oct 26 11:53:28 CST 2015, Created by wenning
+
+Copyright (C) 2015 Potix Corporation. All Rights Reserved.
+
+-->
+<zk>
+	<label multiline="true">
+		input these escaped characters (&#x27; &#x60; &amp;' &lt;' &gt;' &quot;), they should be displayed without any parsed value.
+
+	</label>
+	<zscript><![CDATA[
+	import org.zkoss.zul.ListModelList;
+	import java.util.Arrays;
+	public class ChosenboxViewModel {
+		public ListModel getContactsModel() {
+			ArrayList contactList = new ArrayList();
+			contactList.add("Adam (adam@company.org)");
+			contactList.add("Chris (chris@company.org)");
+			return new ListModelList(contactList);
+		}
+	}
+]]></zscript>
+	<window viewModel="@id('vm') @init('ChosenboxViewModel')" hflex="1">
+		<vlayout sclass="mail" hflex="1">
+			<chosenbox sclass="mailinput" hflex="1"
+					   model="@load(vm.contactsModel)"
+					   creatable="true" createMessage="Create new contact '{0}'" />
+		</vlayout>
+	</window>
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -2066,6 +2066,7 @@ B80-ZK-2860.zul=A,E,Grid,Visible,Row,Rows
 B80-ZK-2920.zul=A,E,Chosenbox,Popup,IE
 B80-ZK-2917.zul=A,E,MVVM,NestedViewModel,Binder,Command
 B80-ZK-2901.zul=A,E,Tree,TreeModel
+B80-ZK-2906.zul=A,E,Chosenbox,CreateMessage,EscapedCharacters,ParsedValue,Escaping
 
 ##
 # Features - 3.0.x version


### PR DESCRIPTION
…> CreateMessage