### PR TITLE
fixed ZK-3006: If the separator key needs to press the shift key, it …

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -49,6 +49,7 @@ ZK 7.0.7
   ZK-3014: Bandpopup content Listbox with hflex="min" get a 1px width if Listbox is updated while popup is not visible
   ZK-2971: listbox scrollposition not updating (keyboard control)
   ZK-2987: Going to the last page causes an empty-like listbox
+  ZK-3006: If the separator key needs to press the shift key, it doesn't work as expected
   
 * Upgrade Notes
 

--- a/zktest/src/archive/test2/B70-ZK-3006.zul
+++ b/zktest/src/archive/test2/B70-ZK-3006.zul
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+B70-ZK-3006.zul
+
+	Purpose:
+		
+	Description:
+		
+	History:
+		Fri, Dec 11, 2015  3:48:28 PM, Created by Christopher
+
+Copyright (C) 2015 Potix Corporation. All Rights Reserved.
+
+-->
+<zk>
+<zscript><![CDATA[
+        ListModelList model = new ListModelList(Locale.getAvailableLocales());
+]]></zscript>
+<label multiline="true">
+	1. change you input method to German (add one if you don't already have it in your system)
+	2. trigger the drop down menu of the chosenbox
+	3. press down and select any item with ";" semicolon key (in german keyboard layout, you have to press "shift + ," to get the ;)
+	4. an item should be selected, instead of actually inputting ; into the chosenbox
+</label>
+<chosenbox separator=";" model="${model}" width="200px"></chosenbox>
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -2034,6 +2034,7 @@ B70-ZK-2929.zul=A,E,Combobox,Width,Scrollbar,Dropdown,Popup
 B70-ZK-3014.zul=A,E,Bandbox,width,hflex,minFlex,Min,popup
 B70-ZK-2971.zul=A,E,Scroll,Paging,Listbox,keyboard,Keydown
 B70-ZK-2987.zul=A,E,scroll,paging,focus,offsetHeight
+B70-ZK-3006.zul=A,E,locale,Keydown,Keycode,doKeyPress,keyUp,Chosenbox
 
 ##
 # Features - 3.0.x version


### PR DESCRIPTION
…doesn't work as expected