### PR TITLE
Fix for ZK-3122 : Check null/empty string for height/width/vflex/hflex before validating value

### DIFF
--- a/zk/src/org/zkoss/zk/ui/HtmlBasedComponent.java
+++ b/zk/src/org/zkoss/zk/ui/HtmlBasedComponent.java
@@ -157,7 +157,7 @@ abstract public class HtmlBasedComponent extends AbstractComponent {
 	/** Sets the height. If null, the best fit is used.
 	 */
 	public void setHeight(String height) {
-		if (getVflex() != null && !getVflex().equals("min")) {
+		if (height != null && !height.isEmpty() && getVflex() != null && !getVflex().equals("min")) {
 			throw new UiException("Not allowed to set vflex and height at the same time except vflex=\"min\"");
 		}
 		setHeight0(height);
@@ -184,7 +184,7 @@ abstract public class HtmlBasedComponent extends AbstractComponent {
 	 * @see #disableClientUpdate
 	 */
 	public void setWidth(String width) {
-		if (getHflex() != null && !getHflex().equals("min")) {
+		if (width != null && !width.isEmpty() && getHflex() != null && !getHflex().equals("min")) {
 			throw new UiException("Not allowed to set hflex and width at the same time except hflex=\"min\"");
 		}
 		setWidth0(width);
@@ -465,7 +465,7 @@ abstract public class HtmlBasedComponent extends AbstractComponent {
 	 * @see #getVflex 
 	 */
 	public void setVflex(String flex) {
-		if (getHeight() != null && !"min".equals(flex)) {
+		if (flex != null && !flex.isEmpty() && getHeight() != null && !"min".equals(flex)) {
 			throw new UiException("Not allowed to set vflex and height at the same time except vflex=\"min\"");
 		}
 		setVflex0(flex);
@@ -516,7 +516,7 @@ abstract public class HtmlBasedComponent extends AbstractComponent {
 	 * @see #getHflex 
 	 */
 	public void setHflex(String flex) {
-		if (getWidth() != null && !"min".equals(flex)) {
+		if (flex != null && !flex.isEmpty() && getWidth() != null && !"min".equals(flex)) {
 			throw new UiException("Not allowed to set hflex and width at the same time except hflex=\"min\"");
 		}
 		setHflex0(flex);


### PR DESCRIPTION
This avoids issues setting Height/Width/Hflex/Vflex from java as outlined in http://tracker.zkoss.org/browse/ZK-3122

