### PR TITLE
ZK-3068: A toolbar with a toolbarbutton does not count as a focusable…

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -3,6 +3,7 @@ ZK 7.0.9
 * Features
 
 * Bugs
+  ZK-3068: A toolbar with a toolbarbutton does not count as a focusable control when giving focus to the first element of a modal window
 
 * Upgrade Notes
 

--- a/zktest/pom.xml
+++ b/zktest/pom.xml
@@ -27,7 +27,7 @@
 		<report.dir>debug/report/</report.dir>
 		<test.dir>debug/test-classes</test.dir>
 	</properties>
-	<version>7.0.8-Eval</version>
+	<version>7.0.9-SNAPSHOT</version>
 	<name>ZK Test</name>
 	<url>http://www.zkoss.org/</url>
 	<description>ZK Test</description>

--- a/zul/src/archive/web/js/zul/wgt/Toolbarbutton.js
+++ b/zul/src/archive/web/js/zul/wgt/Toolbarbutton.js
@@ -338,6 +338,22 @@ zul.wgt.Toolbarbutton = zk.$extends(zul.LabelImageWidget, {
 				}
 			}
 		}
+	},
+	focus_: function (timeout) {
+        if (this._tabindex || this._href || this._upload) {
+            var self = this,
+                n = this.$n();
+            zk.afterAnimate(function () {
+                try {
+                    n.focus();
+                    zk.currentFocus = self;
+                    zjq.fixInput(n);
+                } catch (e) {
+                }
+            }, timeout);
+            return true;
+        }
+	    return false;
 	}
 });
 })();


### PR DESCRIPTION
… control when giving focus to the first element of a modal window