### PR TITLE
ZK-2582: Allow specification of Priority for SelectorComposer's @Listen() Annotation

### DIFF
--- a/zk/src/org/zkoss/zk/ui/select/Selectors.java
+++ b/zk/src/org/zkoss/zk/ui/select/Selectors.java
@@ -203,6 +203,14 @@ public class Selectors {
 					String name = strs[0];
 					if (name == null)
 						name = "onClick";
+ 					// http://tracker.zkoss.org/browse/ZK-2582
+ 					int prio = 0;
+ 					int idx = name.indexOf('(');
+ 					if (idx > 0) {
+ 						int li = name.indexOf(')');
+ 						prio = Integer.parseInt(name.substring(idx+1, li));
+ 						name = name.substring(0, idx);
+ 					}
 					Iterable<Component> iter = iterable(component, strs[1]);
 					// no forwarding, just add to event listener
 					Set<Component> rewired = rewire ? new HashSet<Component>() : null;
@@ -221,7 +229,7 @@ public class Selectors {
 						String mhash = name + "#" + method.toString();
 						if (set.contains(mhash))
 							continue;
-						c.addEventListener(name, new ComposerEventListener(method, controller));
+						c.addEventListener(prio, name, new ComposerEventListener(method, controller));
 						set.add(mhash);
 					}
 				}

--- a/zk/src/org/zkoss/zk/ui/select/Selectors.java
+++ b/zk/src/org/zkoss/zk/ui/select/Selectors.java
@@ -203,14 +203,14 @@ public class Selectors {
 					String name = strs[0];
 					if (name == null)
 						name = "onClick";
- 					// http://tracker.zkoss.org/browse/ZK-2582
- 					int prio = 0;
- 					int idx = name.indexOf('(');
- 					if (idx > 0) {
+					// http://tracker.zkoss.org/browse/ZK-2582
+					int prio = 0;
+					int idx = name.indexOf('(');
+					if (idx > 0) {
  						int li = name.indexOf(')');
- 						prio = Integer.parseInt(name.substring(idx+1, li));
- 						name = name.substring(0, idx);
- 					}
+						prio = Integer.parseInt(name.substring(idx + 1, li));
+						name = name.substring(0, idx);
+					}
 					Iterable<Component> iter = iterable(component, strs[1]);
 					// no forwarding, just add to event listener
 					Set<Component> rewired = rewire ? new HashSet<Component>() : null;


### PR DESCRIPTION
Hi,

this is a pull regest for http://tracker.zkoss.org/browse/ZK-2582 allowing a priority specification in @Listen() annotations.

Sample:
@Listen("onChange(-100) = #myTextBox")

The intention is to have the @Listen()-Bindings executed after the databinder has finished updated all related objects.