### PR TITLE
MouseEvent: Transport metaKey status

### DIFF
--- a/zk/src/org/zkoss/zk/au/AuRequests.java
+++ b/zk/src/org/zkoss/zk/au/AuRequests.java
@@ -65,6 +65,8 @@ public class AuRequests {
 				keys |= MouseEvent.CTRL_KEY;
 			if (getBoolean(data, "shiftKey"))
 				keys |= MouseEvent.SHIFT_KEY;
+			if (getBoolean(data, "metaKey"))
+				keys |= MouseEvent.META_KEY;
 			switch (getInt(data, "which", -1)) {
 			case 1:
 				keys |= MouseEvent.LEFT_CLICK;

--- a/zk/src/org/zkoss/zk/ui/event/MouseEvent.java
+++ b/zk/src/org/zkoss/zk/ui/event/MouseEvent.java
@@ -52,6 +52,10 @@ public class MouseEvent extends Event {
 	 * It might be returned as part of {@link #getKeys}.
 	 */
 	public static final int SHIFT_KEY = 0x004;
+	/** Indicates whether the Meta key is pressed.
+	 * It might be returned as part of {@link #getKeys}.
+	 */
+	public static final int META_KEY = 0x008;
 	/** Indicates whether the left button is clicked.
 	 */
 	public static final int LEFT_CLICK = 0x100;


### PR DESCRIPTION
Hi,

another small patch: We discovered that the "metaKey" status on OSX - especially in context for a listbox - is handled properly on the javascript side (the meta-key allows multi-select individual entries on OSX like the ctrl key on windows), and also reported properly in the AuRequests data JSON object, but it is simply not mapped to the MouseEvent.
This small pull solves this and the meta key is visible on the MouseEvent.