### PR TITLE
Bugfix for ZK-3324 Session Serialization: ConcurrentModificationException

### DIFF
--- a/zk/src/org/zkoss/zk/ui/AbstractComponent.java
+++ b/zk/src/org/zkoss/zk/ui/AbstractComponent.java
@@ -2912,7 +2912,8 @@ public class AbstractComponent implements Component, ComponentCtrl, java.io.Seri
 		if (_auxinf != null && _auxinf.listeners != null)
 			for (Iterator<List<EventListenerInfo>> it = CollectionsX
 					.comodifiableIterator(_auxinf.listeners.values()); it.hasNext();)
-				for (EventListenerInfo li : it.next()) {
+				for (Iterator<EventListenerInfo> itli = CollectionsX.comodifiableIterator(it.next()); itli.hasNext();) {
+					EventListenerInfo li = itli.next();
 					if (uniqueAttrs.add(li.listener)) //ZK-2701: only activate the same object once
 						didActivate(li.listener);
 				}


### PR DESCRIPTION
in AbstractComponent.sessionDidActivate(AbstractComponent.java:2915)

Details in [http://tracker.zkoss.org/browse/ZK-3224](http://tracker.zkoss.org/browse/ZK-3224)