### PR TITLE
Fixed ZK-3411: a component's height doesn't fill up its parent with v…

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -18,6 +18,7 @@ ZK 8.0.4
   ZK-3519: Inconsistent behavior in disabled input based controls
   ZK-3342: Datebox today link date-format
   ZK-3533: Message code not found in msgzul
+  ZK-3411: a component's height doesn't fill up its parent with vflex="1" when there is a vertical scrollbar
 
 * Upgrade Notes
 

--- a/zktest/src/archive/test2/B80-ZK-3411.zul
+++ b/zktest/src/archive/test2/B80-ZK-3411.zul
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+B80-ZK-3411.zul
+
+	Purpose:
+		
+	Description:
+		
+	History:
+		Tue Nov 29 09:50:00 CST 2016, Created by Jack Wei
+
+Copyright (C) 2016 Potix Corporation. All Rights Reserved.
+
+-->
+<zk>
+
+	<zscript><![CDATA[
+		ArrayList cols = new ArrayList();
+		for (int i = 0; i < 10; i++) {
+			cols.add("Column " + i);
+		}
+		ArrayList rows = new ArrayList();
+		for (int i = 0; i < 40; i++) {
+			rows.add("Row " + i);
+		}
+    ]]>
+	</zscript>
+	<window hflex="1" vflex="1">
+		<grid hflex="1" vflex="1" span="true" style="background:#ddd">
+			<columns>
+				<column forEach="${cols}" hflex="min"><label value="${each}" /></column>
+			</columns>
+			<rows>
+				<!--<row forEach="${rows}"><label forEach="${cols}" value="Content content" /></row>-->
+				<row forEach="${rows}">
+					<label value="there" />
+					<label value="should not" />
+					<label value="have extra space" />
+					<label value="at bottom and right" />
+					<label value="between the grid" />
+					<label value="and the browser" />
+					<label value="since" />
+					<label value="hflex is 1" />
+					<label value="and" />
+					<label value="vflex is 1" />
+				</row>
+			</rows>
+		</grid>
+	</window>
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -2282,6 +2282,7 @@ B80-ZK-3505.zul=A,E,Caption,Tabindex,DefaultTabindex
 ##zats##B80-ZK-3519.zul=A,E,Input,disabled,click,onRightClick
 ##zats##B80-ZK-3342.zul=A,E,Datebox,Calendar,today,label
 ##zats##B80-ZK-3533.zul=A,E,Msgzul,i18n,panel,restore
+B80-ZK-3411.zul=A,E,flex,onSize,scrollbar,Grid,resize
 
 ##
 # Features - 3.0.x version


### PR DESCRIPTION
…flex=1 when there is a vertical scrollbar