### PR TITLE
ZK-3534: Function call loop starting at zul.wgt.Popup.close() causes …

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -30,6 +30,7 @@ ZK 8.0.4
   ZK-3312: Unexpected @load binding triggers
   ZK-3499: Difficult to select menuitem in line wrapped menubar
   ZK-3517: ForEach cause NoSuchElementException when using ListModel
+  ZK-3534: Function call loop starting at zul.wgt.Popup.close() causes full browser crash on IE11
 
 * Upgrade Notes
 

--- a/zktest/src/archive/test2/B80-ZK-3534.zul
+++ b/zktest/src/archive/test2/B80-ZK-3534.zul
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+B80-ZK-3534.zul
+
+	Purpose:
+
+	Description:
+
+	History:
+		Thu Dec 15 16:14:32 CST 2016, Created by jameschu
+
+Copyright (C) 2016 Potix Corporation. All Rights Reserved.
+
+-->
+<zk>
+    <label>
+        1. IE 11 only.
+        2. Click on the combobox input element to give it focus.
+        3. Hover the 'test' button, and you would see the popup.
+        4. Move mouse out of the button to close the popup, and you should not see crash.
+    </label>
+    <div>
+        <combobox id="cb" width="210px" text="Please Select" />
+    </div>
+    <div>
+        <button label="test" tooltip="Div2" />
+        <popup width="500px" id="Div2">
+            <label value="test" />
+        </popup>
+    </div>
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -2293,6 +2293,7 @@ B80-ZK-3514.zul=A,M,listbox,grid,Model,AuResponse,javascript,error
 B80-ZK-3312.zul=A,M,Binding,NotifyChange,update,Collection
 ##zats##B80-ZK-3499.zul=A,E,Menu,MenuPopup,Menubar,PopupPosition,Padding
 ##zats##B80-ZK-3517.zul=A,E,ForEach,Exception,Step,List
+B80-ZK-3534.zul=A,E,Popup,focus,IE11
 
 ##
 # Features - 3.0.x version

--- a/zul/src/archive/web/js/zul/wgt/Popup.js
+++ b/zul/src/archive/web/js/zul/wgt/Popup.js
@@ -261,7 +261,7 @@ zul.wgt.Popup = zk.$extends(zul.Widget, {
 						jq(n).blur(); // trigger a missing blur event.
 					} else if (zk.ie && document.activateElement !== n) {
 						//ZK-3244 popup miss focus on input on IE
-						jq(n).focus();
+						zk(n).focus();
 					}
 				}
 			}


### PR DESCRIPTION
…full browser crash on IE11