### PR TITLE
Fixing NullPointerException occurring inside org.zkoss.zk.ui.AbstractComponent#checkParentChild method

### DIFF
--- a/zk/src/org/zkoss/zk/ui/AbstractComponent.java
+++ b/zk/src/org/zkoss/zk/ui/AbstractComponent.java
@@ -1308,14 +1308,16 @@ public class AbstractComponent implements Component, ComponentCtrl, java.io.Seri
 			if (!acp.isChildable())
 				throw new UiException("Child not allowed in " + parent.getClass().getName());
 
-			final Page parentpg = parent.getPage(), childpg = child.getPage();
-			if (parentpg != null && childpg != null && parentpg.getDesktop() != childpg.getDesktop())
-				throw new UiException("The parent and child must be in the same desktop: " + parent);
+			if (child != null) {
+				final Page parentpg = parent.getPage(), childpg = child.getPage();
+				if (parentpg != null && childpg != null && parentpg.getDesktop() != childpg.getDesktop())
+					throw new UiException("The parent and child must be in the same desktop: " + parent);
 
-			final Component oldparent = child.getParent();
-			if (spaceOwnerNoVirtual(parent) != (oldparent != null ? spaceOwnerNoVirtual(oldparent) : childpg))
-				checkIdSpacesDown(child, parent);
-		} else {
+				final Component oldparent = child.getParent();
+				if (spaceOwnerNoVirtual(parent) != (oldparent != null ? spaceOwnerNoVirtual(oldparent) : childpg))
+					checkIdSpacesDown(child, parent);
+			}
+		} else if (child != null) {
 			final Page childpg = child.getPage();
 			if (childpg != null)
 				checkDetach(childpg);


### PR DESCRIPTION
Hello,

This PR fixes `NullPointerException` ocurring inside `org.zkoss.zk.ui.AbstractComponent#checkParentChild` method.

It occurs in the following scenario:

Method `org.zkoss.zk.ui.AbstractComponent#appendChild` calls `org.zkoss.zk.ui.AbstractComponent#insertBefore(child, null)` method and returns its result. Inside `org.zkoss.zk.ui.AbstractComponent#insertBefore` method `org.zkoss.zk.ui.AbstractComponent#checkParentChild(this, newChild)` is called, where `newChild` parameter will be always `null`.

Inside `org.zkoss.zk.ui.AbstractComponent#checkParentChild` method **we are not checking if the `newChild` is not null**, but we should because of method `org.zkoss.zk.ui.AbstractComponent#appendChild` used in the ZK framework, which **calls this method explicitly with `null` as a parameter**.

I also wanted to write a unit test for that bug to avoid its regression, but you have custom project structure, so I don't know where I should put that potential test. You can point me to the correct place and then I can add a missing unit test.

Please review my PR.
I'm looking forward to your reply. 

Kind Regards,
Piotr