### PR TITLE
ZK-3707: splitlayout splitter cursor icon shows only one direction

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -42,6 +42,8 @@ ZK 8.5.0
   ZK-3653: Shadow elements nested parameter leak
   ZK-3618: onClick listener doesn't work on iPad
   ZK-3583: hovering a disabled button closes a popup immediately
+  ZK-3707: splitlayout splitter cursor icon shows only one direction
+  ZK-3708: splitlayout splitter uses inline style makes CSS customization harder
 
 * Upgrade Notes
 

--- a/zktest/src/archive/test2/B85-ZK-3707.zul
+++ b/zktest/src/archive/test2/B85-ZK-3707.zul
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+B85-ZK-3707.zul
+
+	Purpose:
+		
+	Description:
+		
+	History:
+		Wed Jul 19 09:56:00 CST 2017, Created by jameschu
+
+Copyright (C) 2017 Potix Corporation. All Rights Reserved.
+
+-->
+<div width="600px" height="500px">
+    <vlayout vflex="1" hflex="1">
+        <label>
+            Mouse move on the splitter, the resize icon should be two-direction.
+        </label>
+        <splitlayout vflex="1" hflex="1">
+            <div vflex="1">
+                <label value="Area 1"/>
+            </div>
+            <div vflex="1">
+                <label value="Area 2" />
+            </div>
+        </splitlayout>
+        <splitlayout orient="horizontal" vflex="1" hflex="1">
+            <div hflex="1">
+                <label value="Area 1"/>
+            </div>
+            <div hflex="1">
+                <label value="Area 2" />
+            </div>
+        </splitlayout>
+    </vlayout>
+</div>

--- a/zktest/src/archive/test2/B85-ZK-3708.zul
+++ b/zktest/src/archive/test2/B85-ZK-3708.zul
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+B85-ZK-3708.zul
+
+	Purpose:
+		
+	Description:
+		
+	History:
+		Wed Jul 19 09:56:00 CST 2017, Created by jameschu
+
+Copyright (C) 2017 Potix Corporation. All Rights Reserved.
+
+-->
+<zk xmlns:w="client">
+    <div width="600px" height="500px">
+        <label>
+            The splitter width/height should be 100% in css.
+        </label>
+        <vlayout vflex="1" hflex="1">
+            <splitlayout vflex="1" hflex="1">
+                <div vflex="1">
+                    <label value="Area 1"/>
+                </div>
+                <div vflex="1">
+                    <label value="Area 2" />
+                </div>
+            </splitlayout>
+            <splitlayout orient="horizontal" vflex="1" hflex="1">
+                <div hflex="1">
+                    <label value="Area 1"/>
+                </div>
+                <div hflex="1">
+                    <label value="Area 2" />
+                </div>
+            </splitlayout>
+        </vlayout>
+    </div>
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -2329,6 +2329,8 @@ B85-ZK-3320.zul=A,E,ReferenceBinding
 ##zats##B85-ZK-3653.zul=A,E,ShadowElement,Apply,nested
 B85-ZK-3618.zul=A,E,iPad,Safari,Chrome,onClick
 B85-ZK-3583.zul=A,E,Tooltip,popup,disabled,close
+B85-ZK-3707.zul=A,E,css,CustomStyle,Splitlayout
+B85-ZK-3708.zul=A,E,css,CustomStyle,Splitlayout
 
 ##
 # Features - 3.0.x version


### PR DESCRIPTION
ZK-3708: splitlayout splitter uses inline style makes CSS customization harder