### PR TITLE
ZK-3572: Listbox uses deprecated setPreloadSize instead of library property org.zkoss.zul.listbox.preloadSize

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -56,6 +56,7 @@ ZK 8.5.0
   ZK-3650: Spinner missing onChanging if _lastChg == null
   ZK-3614: Chosenbox: getOptIdByElement fails if the desktop of the chosenbox is null
   ZK-3695: jumpy tabbox accordion animation
+  ZK-3572: Listbox uses deprecated setPreloadSize instead of library property org.zkoss.zul.listbox.preloadSize
 
 * Upgrade Notes
 

--- a/zktest/src/archive/test2/B85-ZK-3572.zul
+++ b/zktest/src/archive/test2/B85-ZK-3572.zul
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+B85-ZK-3572.zul
+
+	Purpose:
+		
+	Description:
+		
+	History:
+		Tue Aug 09 11:27:15 CST 2017, Created by bobpeng
+
+Copyright (C) 2017 Potix Corporation. All Rights Reserved.
+
+-->
+<?taglib uri="http://www.zkoss.org/dsp/web/core" prefix="c"?>
+<zk>
+	<zscript><![CDATA[
+		// build large model
+		ListModelList myModel = new ListModelList(Locale.getAvailableLocales());
+		myModel.addAll(myModel);
+		myModel.addAll(myModel);
+	]]></zscript>
+	<borderlayout height="600px">
+        <west sclass="navbar-system-scrollbar">
+			<window title="listbox demo" border="normal" width="250px">
+			    <listbox model="${myModel}" height="500px" id="box" preloadSize="20">
+			    	<template name="model">
+			    		<listitem label='${c:cat3(forEachStatus.index , " " , each)}'>
+			    		</listitem>
+			    	</template>
+			    </listbox>
+			    <zscript><![CDATA[
+					//Using Live data (CE render on demand)
+			    	box.setAttribute("org.zkoss.zul.listbox.rod",false);
+					//set the initial number of rows to be rendered
+			    	box.setAttribute("org.zkoss.zul.listbox.initRodSize",60);
+					//set the number of row to be rendered in each loading cycle
+			    	box.setAttribute("org.zkoss.zul.listbox.preloadSize",70);
+			    ]]></zscript>
+			</window>
+        </west>
+        <center>
+            <label multiline="true">
+            1. Open browser console, and switch to network tab
+            2. Scroll the sidebar of listbox over item 50
+            3. Check how many additional items listbox loaded (the information would be in the brower console / network / zkau request)
+            Expect: 70 items (based on library property "org.zkoss.zul.listbox.preloadSize")
+            Error: 20 items
+            </label>
+        </center>
+    </borderlayout>
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -2340,6 +2340,7 @@ B85-ZK-3650.zul=A,E,Spinner,InputWidget,onChanging,onBlur
 F85-ZK-3336.zul=A,E,Tbeditor
 ##zats##B85-ZK-3614.zul=B,E,Chosenbox,Model,ModelListener,Detach
 B85-ZK-3695.zul=A,M,Tabbox,Accordion,Animation,Jumpy,Jerky,Padding,Margin,Border
+B85-ZK-3572.zul=A,E,Listbox,preloadSize,library property
 
 ##
 # Features - 3.0.x version

--- a/zul/src/org/zkoss/zul/Listbox.java
+++ b/zul/src/org/zkoss/zul/Listbox.java
@@ -3705,10 +3705,12 @@ public class Listbox extends MeshElement {
 			if (cnt == 0)
 				return; // nothing to do
 
-			cnt = 20 - cnt;
-			if (cnt > 0 && _preloadsz > 0) { // Feature 1740072: pre-load
-				if (cnt > _preloadsz)
-					cnt = _preloadsz; // at most 8 more to load
+			// B85-ZK-3572 get size using preloadSize()
+			int size = preloadSize();
+			cnt = size - cnt;
+			if (cnt > 0 && size > 0) { // Feature 1740072: pre-load
+				if (cnt > size)
+					cnt = size; // at most 8 more to load
 
 				// 1. locate the first item found in items
 				final List<Listitem> toload = new LinkedList<Listitem>();


### PR DESCRIPTION
get value from library property "org.zkoss.zul.listbox.preloadSize" if it exists
and set value to _preloadsz