### PR TITLE
ZK-3507: Shift + up key can deselect listitems

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -12,6 +12,7 @@ ZK 8.5.0
   ZK-3336: tbeditor version update
   ZK-3315: allow JS overrides for onResponseReady callback
   ZK-3690: Size by n-rows support for all MeshWidgets
+  ZK-3507: Shift + up key can deselect listitems
 
 * Bugs
   ZK-3659: global <max-upload-size> is ignored

--- a/zktest/src/archive/test2/F85-ZK-3507.zul
+++ b/zktest/src/archive/test2/F85-ZK-3507.zul
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+F85-ZK-3507.zul
+
+	Purpose:
+		
+	Description:
+		
+	History:
+		Tue Aug 10 11:52:15 CST 2017, Created by bobpeng
+
+Copyright (C) 2017 Potix Corporation. All Rights Reserved.
+
+-->
+<zk>
+	<label value="listbox"/>
+    <listbox id="box" multiple="true" checkmark="true" width="300px">
+        <listitem label="Mary"></listitem>
+        <listitem label="John"></listitem>
+        <listitem label="Jane"></listitem>
+        <listitem label="Henry"></listitem>
+        <listitem label="Mark"></listitem>
+        <listitem label="Bess"></listitem>
+        <listitem label="Cathy"></listitem>
+    </listbox>
+    <label value="tree"/>
+    <tree id="tree" rows="7" multiple="true" checkmark="true" width="300px">
+	    <treechildren>
+	        <treeitem label="Item 1"/>
+	        <treeitem>
+	            <treerow label="Item 2"/>
+	            <treechildren>
+	                <treeitem>
+	                    <treerow label="Item 2.1"/>
+	                    <treechildren>
+	                    	<treeitem label="Item 2.1.1"/>
+	                    	<treeitem label="Item 2.1.2"/>
+	                    </treechildren>
+	                </treeitem>
+	                <treeitem label="Item 2.2"/>
+	            </treechildren>
+	        </treeitem>
+	        <treeitem label="Item 3"/>
+	    </treechildren>
+	</tree>
+	<label multiline="true">
+		1. Select a random item, except the last one
+		2. Press Shift + down, and next item will be selected
+		3. Press Shift + up, deselect one item
+	</label>
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -2727,6 +2727,7 @@ F85-ZK-3711-2.zul=C,E,history.pushState,MVC
 ##zats##F85-ZK-3315.zul=A,E,AuResponse,zk.override
 F85-ZK-3315-comet.zul=A,E,CometServerPush,zk.override
 F85-ZK-3690.zul=A,E,MeshWidget,Grid,rows
+F85-ZK-3507.zul=A,E,Listbox,Tree,shiftUp,deselect
 
 # Complex Test Case
 #

--- a/zul/src/archive/web/js/zul/sel/SelectWidget.js
+++ b/zul/src/archive/web/js/zul/sel/SelectWidget.js
@@ -713,7 +713,7 @@ zul.sel.SelectWidget = zk.$extends(zul.mesh.MeshWidget, {
 
 		if (step > 0 || (step < 0 && row)) {
 			if (row && shift && !row.isDisabled() && row.isSelectable()) // Bug ZK-1715: not select item if disabled.
-				this._toggleSelect(row, true, evt);
+				this._toggleSelect(row, step > 0, evt); // F85-ZK-3507: shift + down: select multiple items, shift + up: deselect multiple items
 			var nrow = row ? row.$n() : null;
 			for (;;) {
 				if (!nrow) { // no focused/selected item yet


### PR DESCRIPTION
Copy the solution from the workaround attached js file.
This feature will not only be applied on Listbox but also Tree.