### PR TITLE
ZK-3328: jq.alert default "OK" button doesn't use internationalized m…

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -57,6 +57,7 @@ ZK 8.5.0
   ZK-3614: Chosenbox: getOptIdByElement fails if the desktop of the chosenbox is null
   ZK-3695: jumpy tabbox accordion animation
   ZK-3572: Listbox uses deprecated setPreloadSize instead of library property org.zkoss.zul.listbox.preloadSize
+  ZK-3328: jq.alert default "OK" button doesn't use internationalized messages
 
 * Upgrade Notes
 

--- a/zktest/src/archive/test2/B85-ZK-3328.zul
+++ b/zktest/src/archive/test2/B85-ZK-3328.zul
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+B85-ZK-3328.zul
+
+	Purpose:
+		
+	Description:
+		
+	History:
+		Wed Aug 2 16:56:00 CST 2017, Created by jameschu
+
+Copyright (C) 2017 Potix Corporation. All Rights Reserved.
+
+-->
+<zk xmlns:w="client">
+    <zscript><![CDATA[
+	import java.util.Locale;
+	import org.zkoss.web.Attributes;
+	import org.zkoss.zk.ui.Sessions;
+	import org.zkoss.util.Locales;
+	import org.zkoss.zk.ui.util.Clients;
+	Locale locale = new Locale("zh", "ZH");
+	Sessions.getCurrent().setAttribute(Attributes.PREFERRED_LOCALE, locale);
+	Clients.reloadMessages(locale);
+	Locales.setThreadLocal(locale);
+]]></zscript>
+    <label>Click the btn, and you should see the "ok" in Chinese.</label>
+    <button id="btn" label="click" w:onClick="jq.alert('test');"/>
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -2341,6 +2341,7 @@ F85-ZK-3336.zul=A,E,Tbeditor
 ##zats##B85-ZK-3614.zul=B,E,Chosenbox,Model,ModelListener,Detach
 B85-ZK-3695.zul=A,M,Tabbox,Accordion,Animation,Jumpy,Jerky,Padding,Margin,Border
 B85-ZK-3572.zul=A,E,Listbox,preloadSize,library property
+B85-ZK-3328.zul=A,E,jQuery,Alert,i18n
 
 ##
 # Features - 3.0.x version

--- a/zul/src/archive/web/js/zul/dom.js
+++ b/zul/src/archive/web/js/zul/dom.js
@@ -58,7 +58,7 @@ it will be useful, but WITHOUT ANY WARRANTY.
 			btns.push(newButton(nm, typeof f == 'function' ? f : null));
 		}
 		if (!btns.length)
-			btns.push(newButton('OK'));
+			btns.push(newButton(msgzul.OK));
 		return btns;
 	}
 


### PR DESCRIPTION
…essages