### PR TITLE
fixed Javadoc generation fails with jdk1.8.0_121 or later

### DIFF
--- a/build.target.xml
+++ b/build.target.xml
@@ -401,9 +401,9 @@ if="deploy.tomcat.required">
 	 author="true" protected="true" version="true" use="true"
 	 windowtitle="${project.title} ${project.version} API"
 	 doctitle="${project.title} ${project.version} API"
-	 additionalparam="-breakiterator -source ${source.version} ${jdk8.property}">
+	 additionalparam="--allow-script-in-comments -breakiterator -source ${source.version} ${jdk8.property}">
 	 <bottom><![CDATA[Copyright &copy; 2005-2011 Potix Corporation. All Rights Reserved.
-<a href=\"http://sourceforge.net\"><img src=\"http://sourceforge.net/sflogo.php?group_id=152762\&amp;type=1\" width=\"88\" height=\"31\" border=\"0\" alt=\"SourceForge.net Logo\" /></a><script type=\"text/javascript\">if (location.href.indexOf('zkoss.org') >= 0) {var gaJsHost = ((\"https:\" == document.location.protocol) ? \"https://ssl.\" : \"http://www.\");document.write(unescape(\"%3Cscript src='\" + gaJsHost + \"google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E\"));}</script><script type=\"text/javascript\">if (location.href.indexOf('zkoss.org') >= 0) {var pageTracker = _gat._getTracker(\"UA-121377-3\");pageTracker._setDomainName(\"zkoss.org\");pageTracker._initData();pageTracker._trackPageview();}</script>
+<a href="http://sourceforge.net"><img src="http://sourceforge.net/sflogo.php?group_id=152762&amp;type=1" width="88" height="31" border="0" alt="SourceForge.net Logo" /></a><script type="text/javascript">if (location.href.indexOf('zkoss.org') >= 0) {var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));}</script><script type="text/javascript">if (location.href.indexOf('zkoss.org') >= 0) {var pageTracker = _gat._getTracker("UA-121377-3");pageTracker._setDomainName("zkoss.org");pageTracker._initData();pageTracker._trackPageview();}</script>
 	 ]]></bottom>
 		<classpath>
 			<pathelement path="${javadoc.class.path}"/>


### PR DESCRIPTION
 See http://www.oracle.com/technetwork/java/javase/8u121-relnotes-3315208.html

tools/javadoc(tool)

> New --allow-script-in-comments option for javadoc
> The javadoc tool will now reject any occurrences of JavaScript code in the javadoc documentation comments and command-line options, unless the command-line option, --allow-script-in-comments is specified.

> With the --allow-script-in-comments option, the javadoc tool will preserve JavaScript code in documentation comments and command-line options. An error will be given by the javadoc tool if JavaScript code is found and the command-line option is not set.
> JDK-8138725 (not public)