### PR TITLE
ZK-3734: Doublebox with format attribute specified doesn't trigger a …

### DIFF
--- a/zk/src/archive/web/js/zk/zk.js
+++ b/zk/src/archive/web/js/zk/zk.js
@@ -1502,6 +1502,12 @@ zk.$intercepts(zul.inp.Combobox, {
 		|| // ZK-2888, in iphone with chrome, it may not have version attribute.
 		(iosver = agent.match(/ os \d/)) && iosver[0].replace(' os ', ''));
 
+	zk.ipad = zk.webkit && /ipad/.test(agent) && (
+		//ZK-2245: add version info to zk.ios
+		(iosver = agent.match(/version\/\d/)) && iosver[0].replace('version/', '')
+		|| // ZK-2888, in iphone with chrome, it may not have version attribute.
+		(iosver = agent.match(/ os \d/)) && iosver[0].replace(' os ', ''));
+
 	zk.android = zk.webkit && (agent.indexOf('android') >= 0);
 	zk.mobile = zk.ios || zk.android;
 	zk.css3 = true;

--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -63,6 +63,7 @@ ZK 8.5.2
   ZK-3792: enter am but Datebox converts it to PM
   ZK-3838: users can paste non-digital characters into a intbox
   ZK-3921: ROD grid loses scroll position when hiding/showing columns
+  ZK-3734: Doublebox with format attribute specified doesn't trigger a numeric keyboard in iPad
 
 * Upgrade Notes
 

--- a/zktest/src/archive/test2/B85-ZK-3734.zul
+++ b/zktest/src/archive/test2/B85-ZK-3734.zul
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+B85-ZK-3734.zul
+
+        Purpose:
+                
+        Description:
+                
+        History:
+                Thu May 31 11:51:20 CST 2018, Created by klyve
+
+Copyright (C) 2018 Potix Corporation. All Rights Reserved.
+
+-->
+
+<zk>
+	<label multiline="true">
+		1. Open the zul by ipad or android device.
+		2. Tap the first doublebox then tap the second double box again, you should see the same type of input keyboards.
+	</label>
+	<doublebox/>
+	<doublebox format="#,###,##0.00"/>
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -2464,6 +2464,7 @@ B85-ZK-3646.zul=A,E,chrome,a,mailto
 ##ztl##B85-ZK-3792.zul=A,E,Datebox,am
 B85-ZK-3838.zul=A,E,InputWidget,copy,paste,string,number,IE9
 ##ztl##B85-ZK-3921.zul=A,E,Grid,Listbox,Tree,ROD,scrollTop
+B85-ZK-3905.zul=A,E,ipad,android,numberInputWidget,keyboardStyle
 
 ##
 # Features - 3.0.x version

--- a/zul/src/archive/web/js/zul/inp/NumberInputWidget.js
+++ b/zul/src/archive/web/js/zul/inp/NumberInputWidget.js
@@ -95,6 +95,14 @@ zul.inp.NumberInputWidget = zk.$extends(zul.inp.FormatWidget, {
 	},
 	getType: function () {
 		return zk.mobile && !this._format && !this._locale ? 'number' : this._type;
+	},
+	domAttrs_: function (no) {
+		var attr = this.$supers('domAttrs_', arguments);
+		if ((!no || !no.text) && zk.ios && zk.ipad)
+			attr += ' pattern="[0-9]*"';
+		else if ((!no || !no.text) && zk.android)
+			attr += ' inputmode="numeric"';
+		return attr;
 	}
 });
 })();


### PR DESCRIPTION
…numeric keyboard in iPad