### PR TITLE
ZK-3969: MVVM viewmodel name bleed into include / other idspace

### DIFF
--- a/zkbind/src/org/zkoss/bind/AnnotateBinder.java
+++ b/zkbind/src/org/zkoss/bind/AnnotateBinder.java
@@ -76,11 +76,6 @@ public class AnnotateBinder extends BinderImpl {
 		BinderUtil.markHandling(this.getView(), this);
 	}
 
-	protected void loadComponent0(Component comp, boolean loadinit) {
-		new AnnotateBinderHelper(this).initComponentBindings(comp);
-		super.loadComponent0(comp, loadinit);
-	}
-
 	/**
 	 * Internal use only
 	 */

--- a/zkbind/src/org/zkoss/bind/tracker/impl/BindUiLifeCycle.java
+++ b/zkbind/src/org/zkoss/bind/tracker/impl/BindUiLifeCycle.java
@@ -23,8 +23,10 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.zkoss.bind.AnnotateBinder;
 import org.zkoss.bind.BindComposer;
 import org.zkoss.bind.Binder;
+import org.zkoss.bind.impl.AnnotateBinderHelper;
 import org.zkoss.bind.impl.BinderImpl;
 import org.zkoss.bind.impl.BinderUtil;
 import org.zkoss.bind.sys.BinderCtrl;
@@ -95,6 +97,7 @@ public class BindUiLifeCycle implements UiLifeCycle {
 				public void onEvent(Event event) throws Exception {
 					final Component comp = event.getTarget();
 					comp.removeEventListener(BinderImpl.ON_BIND_INIT, this);
+					getExtension().removeLifeCycleHandling(comp);
 					reInitBinder(comp);
 				}
 			});
@@ -155,6 +158,10 @@ public class BindUiLifeCycle implements UiLifeCycle {
 		//check if it is handling, if yes then skip to evaluate it.
 		if (BindUiLifeCycle.getExtension().isLifeCycleHandling(comp)) {
 			return false;
+		}
+
+		if (binder instanceof AnnotateBinder) {
+			new AnnotateBinderHelper(binder).initComponentBindings(comp);
 		}
 
 		//ZK-1699, mark the comp and it's children are handling.

--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -89,6 +89,7 @@ ZK 8.5.2
   ZK-3925: notification message affects panel size after maximize
   ZK-3934: hidden columns shifting cells
   ZK-3944: Getting IllegalStateException: can only add one element
+  ZK-3969: MVVM viewmodel name bleed into include / other idspace
 
 * Upgrade Notes
 

--- a/zktest/src/archive/test2/B85-ZK-3969-include.zul
+++ b/zktest/src/archive/test2/B85-ZK-3969-include.zul
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+B85-ZK-3969-include.zul
+
+	Purpose:
+		
+	Description:
+		
+	History:
+		Tue Jun 26 11:27:12 CST 2018, Created by rudyhuang
+
+Copyright (C) 2018 Potix Corporation. All Rights Reserved.
+
+-->
+<zk>
+    <div viewModel="@id('vm') @init('org.zkoss.zktest.test2.B85_ZK_3969VM')">
+        <div children="@load(vm.valueList) @template('default')">
+            <template name="default">
+                <div>
+                    <label value="@load(vm.stringValue)" />
+                </div>
+            </template>
+        </div>
+    </div>
+</zk>

--- a/zktest/src/archive/test2/B85-ZK-3969.zul
+++ b/zktest/src/archive/test2/B85-ZK-3969.zul
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+B85-ZK-3969.zul
+
+	Purpose:
+		
+	Description:
+		
+	History:
+		Tue Jun 26 11:27:12 CST 2018, Created by rudyhuang
+
+Copyright (C) 2018 Potix Corporation. All Rights Reserved.
+
+-->
+<zk>
+    <zscript>
+        //any vm object
+        class OuterVm{}
+        OuterVm out = new OuterVm();
+    </zscript>
+    <window viewModel="@id('vm') @init(out)">
+        <include src='@load("./B85-ZK-3969-include.zul")' />
+    </window>
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -2486,6 +2486,7 @@ B85-ZK-3927.zul=A,E,MeshWidget,HeadWidget,alignment
 ##zats##B85-ZK-3811.zul=A,E,PathELResolver,BindELResolver,getValue,tieValue
 ##ztl##B85-ZK-3934.zul=A,E,Mesh,Listcell,Cell,Treecell,visible
 ##zats##B85-ZK-3944.zul=A,E,java.util.Date,java.sql.Timestamp,equals
+##zats##B85-ZK-3969.zul=A,E,Include,MVVM,ViewModel,EL
 
 ##
 # Features - 3.0.x version

--- a/zktest/src/org/zkoss/zktest/bind/issue/B01194NestedVMInit.java
+++ b/zktest/src/org/zkoss/zktest/bind/issue/B01194NestedVMInit.java
@@ -18,12 +18,14 @@ package org.zkoss.zktest.bind.issue;
 
 import java.util.HashMap;
 
+import org.zkoss.bind.Binder;
 import org.zkoss.bind.annotation.AfterCompose;
 import org.zkoss.bind.annotation.BindingParam;
 import org.zkoss.bind.annotation.ContextParam;
 import org.zkoss.bind.annotation.ContextType;
 import org.zkoss.bind.annotation.Default;
 import org.zkoss.bind.annotation.Init;
+import org.zkoss.bind.impl.AnnotateBinderHelper;
 import org.zkoss.zk.ui.Component;
 import org.zkoss.zk.ui.select.Selectors;
 import org.zkoss.zk.ui.select.annotation.Wire;
@@ -82,7 +84,8 @@ public class B01194NestedVMInit {
 	
 	@AfterCompose
 	public void doAfterCompose(@BindingParam("type")@Default("user") String type,
-			@ContextParam(ContextType.VIEW) Component self) {
+			@ContextParam(ContextType.VIEW) Component self, 
+			@ContextParam(ContextType.BINDER) Binder binder) {
 		
 		Selectors.wireComponents(self, this, false);
 		HashMap<String, String[]> annotAttrs = new HashMap<String, String[]>();
@@ -91,6 +94,7 @@ public class B01194NestedVMInit {
 		headerNameLb.setParent(headerNameLbOuter);
 		headerNameLb.setId("headerNameLb");
 		headerNameLb.addAnnotation("value", "load", annotAttrs);
+		new AnnotateBinderHelper(binder).initComponentBindings(headerNameLb);
 	}
 	
 	public VM2 getInnerVm() {

--- a/zktest/src/org/zkoss/zktest/test2/B85_ZK_3969VM.java
+++ b/zktest/src/org/zkoss/zktest/test2/B85_ZK_3969VM.java
@@ -1,0 +1,31 @@
+/* B85_ZK_3969VM.java
+
+	Purpose:
+		
+	Description:
+		
+	History:
+		Tue Jun 26 11:29:09 CST 2018, Created by rudyhuang
+
+Copyright (C) 2018 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.test2;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author rudyhuang
+ */
+public class B85_ZK_3969VM {
+	public List<String> getValueList() {
+		List<String> model = new ArrayList<String>();
+		model.add("value1");
+		model.add("value2");
+		return model;
+	}
+
+	public String getStringValue() {
+		return "string value";
+	}
+}

--- a/zktest/test/java/org/zkoss/zktest/zats/test2/B85_ZK_3969Test.java
+++ b/zktest/test/java/org/zkoss/zktest/zats/test2/B85_ZK_3969Test.java
@@ -1,0 +1,26 @@
+/* B85_ZK_3969Test.java
+
+	Purpose:
+		
+	Description:
+		
+	History:
+		Tue Jun 26 11:34:31 CST 2018, Created by rudyhuang
+
+Copyright (C) 2018 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import org.junit.Test;
+
+import org.zkoss.zktest.zats.ZATSTestCase;
+
+/**
+ * @author rudyhuang
+ */
+public class B85_ZK_3969Test extends ZATSTestCase {
+	@Test
+	public void test() {
+		connect();
+	}
+}


### PR DESCRIPTION
Notice: it breaks ZK-3871 (Have told to Klyve)

Before merging, merge https://github.com/zkoss/zk/pull/1179 first!