### PR TITLE
Bug: LibraryProperty classWebResource doesn't work with css.dsp file

### DIFF
--- a/zcommon/src/org/zkoss/util/resource/ResourceCache.java
+++ b/zcommon/src/org/zkoss/util/resource/ResourceCache.java
@@ -95,6 +95,8 @@ public class ResourceCache<K, V> extends CacheMap<Object, Object> {
 	@SuppressWarnings("unchecked")
 	public V get(Object src) {
 		WaitLock lock = null;
+		String resourceCachest = Library.getProperty("org.zkoss.web.classWebResource.cache");
+		boolean resourceCache = resourceCachest != null ? Boolean.parseBoolean(resourceCachest) : true;
 		for (;;) {
 			Info ri = null;
 			synchronized (this) {
@@ -112,7 +114,7 @@ public class ResourceCache<K, V> extends CacheMap<Object, Object> {
 			//check whether cached is valid
 			if (ri != null) {
 				synchronized (ri) {
-					if (ri.isValid())
+					if (ri.isValid() && resourceCache)
 						return ri.getResource(); //reuse cached
 				}
 				//invalid, so remove it (if not updated by others)

--- a/zktest/src/archive/WEB-INF/zk.xml
+++ b/zktest/src/archive/WEB-INF/zk.xml
@@ -53,11 +53,11 @@ Copyright (C) 2006 Potix Corporation. All Rights Reserved.
 		you upgraded ZK to a newer version.
 		However, it is better to turn the cache off when you are developing
 		a theme or a component.
+	-->
 	<library-property>
 		<name>org.zkoss.web.classWebResource.cache</name>
 		<value>false</value>
 	</library-property>
-	-->
 	
 	<!-- Turn on if you want to cache by etag for dynamic resource.
 	<library-property>


### PR DESCRIPTION
The library property org.zkoss.web.classWebResource.cache doesn't work properly when the attribute set as false. It can speed up the timing of modifying the themes(it doesn't need to restart the server after modifying the themes).