### PR TITLE
ZK-4292: Dates.newInstance() returns an incorrect year when the year …

### DIFF
--- a/zk/src/archive/web/js/zk/dateImpl.js
+++ b/zk/src/archive/web/js/zk/dateImpl.js
@@ -30,6 +30,7 @@ var Dates = {
 			tz = param._timezone;
 		} else if (param instanceof Array) { // [y, m, d, hr, min, sec, millisec]
 			var d = new Date(Date.UTC.apply(null, param));
+			if (param[0] < 100) d.setUTCFullYear(param[0]); //ZK-4292: incorrect year when the year is less than 100
 			m = zk.mm.tz([d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate(),
 				d.getUTCHours(), d.getUTCMinutes(), d.getUTCSeconds(), d.getUTCMilliseconds()], tz);
 		}

--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -33,6 +33,7 @@ ZK 8.6.2
   ZK-4208: Can't close a notification
   ZK-4233: Messagebox show called inside include in defer mode doesn't show if include is refreshed
   ZK-4255: MVVM constraints output Expectable exceptions to log
+  ZK-4292: Dates.newInstance() returns an incorrect year when the year is less than 100
 
 * Upgrade Notes
 

--- a/zktest/src/archive/test2/B86-ZK-4292.zul
+++ b/zktest/src/archive/test2/B86-ZK-4292.zul
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+B86-ZK-4292.zul
+
+		Purpose:
+		
+		Description:
+		
+		History:
+				Wed May 15 11:38:09 CST 2019, Created by leon
+
+Copyright (C) 2019 Potix Corporation. All Rights Reserved.
+
+-->
+<zk xmlns:w="client">
+	<script><![CDATA[
+		function test(year) {
+			zk.log(Dates.newInstance([year, 0, 1, 0, 0, 0, 0], 'Asia/Taipei').getFullYear());
+		}
+	]]></script>
+	<label multiline="true">
+		1. click the "test(100)" button, you should see "100" in zk log.
+		2. click the "test(99)" button, you should see "99" in zk log.
+	</label>
+	<button label="test(100)" w:onClick="test(100)"></button>
+	<button label="test(99)" w:onClick="test(99)"></button>
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -2689,6 +2689,7 @@ B86-ZK-4201.zul,A,E=Listbox,Focus,Mobile
 ##zats##B86-ZK-4208.zul=A,E,Notification,Layout
 ##zats##B86-ZK-4233.zul=A,E,Messagebox,CreateComponents
 B86-ZK-4255.zul=A,E,Exception,ServerLog
+##zats##B86-ZK-4292.zul,A,E,dateImpl
 
 ##
 # Features - 3.0.x version

--- a/zktest/test/java/org/zkoss/zktest/zats/test2/B86_ZK_4292Test.java
+++ b/zktest/test/java/org/zkoss/zktest/zats/test2/B86_ZK_4292Test.java
@@ -1,0 +1,30 @@
+/* B86_ZK_4292Test.java
+
+		Purpose:
+		
+		Description:
+		
+		History:
+				Wed May 15 12:43:02 CST 2019, Created by leon
+
+Copyright (C) 2019 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.zkoss.zktest.zats.WebDriverTestCase;
+
+public class B86_ZK_4292Test extends WebDriverTestCase {
+	@Test
+	public void test() {
+		connect();
+		waitResponse();
+		click(jq("@button:first"));
+		waitResponse();
+		Assert.assertEquals("100", getZKLog());
+		click(jq("@button:last"));
+		waitResponse();
+		Assert.assertEquals("100\n99", getZKLog());
+	}
+}


### PR DESCRIPTION
…is less than 100