### PR TITLE
ZK-4345: XSD doesn't define hflex and vflex for charts

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -4,6 +4,10 @@ ZK 8.6.3
 * Bugs
   ZK-4336: iframe not sizing correctly on ios
   ZK-4313: load moment js scripts statically
+  ZK-4345: XSD doesn't define hflex and vflex for charts
+  ZK-4348: zul XSD declares the attribute "badgeText" in wrong case
+  ZK-4350: zul XSD doesn't declare onCreate for charts
+  ZK-4356: missing "text" attribute on timebox in zul XSD
 
 * Upgrade Notes
 

--- a/zul/src/archive/metainfo/xml/zul.xsd
+++ b/zul/src/archive/metainfo/xml/zul.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.zkoss.org/2005/zul"
-	targetNamespace="http://www.zkoss.org/2005/zul" elementFormDefault="qualified" version="8.6.2.201905131112">
+	targetNamespace="http://www.zkoss.org/2005/zul" elementFormDefault="qualified" version="8.6.3.201908010940">
 	<!--
 	SIMPLETYPE
 	-->
@@ -501,6 +501,7 @@
 		<xs:attribute name="fulfill" type="xs:string" use="optional" />
 		<xs:attribute name="id" type="xs:string" use="optional" />
 		<xs:attribute name="mold" type="xs:string" use="optional" />
+		<xs:attribute name="onCreate" type="xs:string" use="optional" />
 		<xs:attribute name="onFulfill" type="xs:string" use="optional" />
 		<xs:attribute name="stubonly" type="xs:string" use="optional" />
 		<xs:attribute name="use" type="xs:string" use="optional" />
@@ -525,7 +526,6 @@
 		<xs:attribute name="tooltiptext" type="xs:string" use="optional" />
 		<xs:attribute name="zindex" type="intType" use="optional" />
 		<xs:attribute name="renderdefer" type="intType" use="optional" />
-		<xs:attribute name="onCreate" type="xs:string" use="optional" />
 		<xs:attribute name="onDrop" type="xs:string" use="optional" />
 		<xs:attribute name="action" type="xs:string" use="optional" />
 		<xs:attribute name="hflex" type="xs:string" use="optional" />
@@ -551,6 +551,7 @@
 		<xs:attribute name="maxlength" type="intType" use="optional" />
 		<xs:attribute name="cols" type="intType" use="optional" />
 		<xs:attribute name="insertedText" type="xs:string" use="optional" />
+		<xs:attribute name="text" type="xs:string" use="optional" />
 		<xs:attribute name="onChange" type="xs:string" use="optional" />
 		<xs:attribute name="onChanging" type="xs:string" use="optional" />
 		<xs:attribute name="onFocus" type="xs:string" use="optional" />
@@ -1321,6 +1322,8 @@
 		<xs:attribute name="zclass" type="xs:string" use="optional" />
 		<xs:attribute name="zoomType" type="xs:string" use="optional" />
 		<xs:attribute name="onSelection" type="xs:string" use="optional" />
+		<xs:attribute name="hflex" type="xs:string" use="optional" />
+		<xs:attribute name="vflex" type="xs:string" use="optional" />
 		<xs:attributeGroup ref="mouseAttrGroup" />
 		<xs:attributeGroup ref="rootAttrGroup" />
 		<xs:attributeGroup ref="plotAttrGroup" />
@@ -2366,7 +2369,7 @@
 		</xs:choice>
 		<xs:attributeGroup ref="labelImageElementAttrGroup" />
 		<xs:attribute name="onOpen" type="xs:string" use="optional" />
-		<xs:attribute name="badgetext" type="xs:string" use="optional" />
+		<xs:attribute name="badgeText" type="xs:string" use="optional" />
 	</xs:complexType>
 	<!-- navbar -->
 	<xs:element name="navbar" type="navbarType" />


### PR DESCRIPTION
ZK-4348: zul XSD declares the attribute "badgeText" in wrong case
ZK-4350: zul XSD doesn't declare onCreate for charts
ZK-4356: missing "text" attribute on timebox in zul XSD