### PR TITLE
Upgrade to Chromium 77.0.3835.0 (8.6 branch)

### DIFF
--- a/zktest/pom.xml
+++ b/zktest/pom.xml
@@ -429,7 +429,7 @@
 		<dependency>
 			<groupId>io.github.bonigarcia</groupId>
 			<artifactId>webdrivermanager</artifactId>
-			<version>3.4.0</version>
+			<version>3.6.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/zktest/test/java/org/zkoss/zktest/zats/ChromiumHeadlessDriver.java
+++ b/zktest/test/java/org/zkoss/zktest/zats/ChromiumHeadlessDriver.java
@@ -30,11 +30,13 @@ import org.slf4j.LoggerFactory;
  */
 public class ChromiumHeadlessDriver extends ChromeDriver {
 	private static final Logger LOG = LoggerFactory.getLogger(ChromiumHeadlessDriver.class);
-	private static final String CHROME_DRIVER_VERSION = "74";
-	private static final int CHROMIUM_BINARY_REVISION = 637110; // from puppeteer v1.13.0 Chromium 74.0.3723.0 (r637110)
+	private static final String CHROME_DRIVER_VERSION = "77.0.3865.40";
+	private static final int CHROMIUM_BINARY_REVISION = 672088; // from puppeteer v1.18.1 Chromium 77.0.3835.0
 
 	static {
 		WebDriverManager.chromedriver().version(CHROME_DRIVER_VERSION).setup();
+		System.setProperty("webdriver.chrome.logfile", "/tmp/chromedriver.log");
+		System.setProperty("webdriver.chrome.verboseLogging", "true");
 	}
 
 	public ChromiumHeadlessDriver() {

--- a/zktest/test/java/org/zkoss/zktest/zats/WebDriverTestCase.java
+++ b/zktest/test/java/org/zkoss/zktest/zats/WebDriverTestCase.java
@@ -99,6 +99,7 @@ public abstract class WebDriverTestCase {
 	protected ChromeOptions getWebDriverOptions() {
 		ChromeOptions options = new ChromeOptions();
 		options.addArguments("window-size=1920,1080");
+		options.setExperimentalOption("w3c", false); // Temporary workaround for TouchAction
 		return options;
 	}
 
@@ -587,7 +588,7 @@ public abstract class WebDriverTestCase {
 			paths.add(file.toAbsolutePath().toString());
 		}
 
-		element.eval("show()"); // needed to interact
+		eval(element + ".show()"); // needed to interact
 		String value = String.join("\n", paths);
 		WebElement input = (WebElement) ((JavascriptExecutor) driver).executeScript(JS_DROP_FILES, toElement(element), offsetX, offsetY);
 		input.sendKeys(value);

--- a/zktest/test/java/org/zkoss/zktest/zats/test2/F50_2940704_GridTest.java
+++ b/zktest/test/java/org/zkoss/zktest/zats/test2/F50_2940704_GridTest.java
@@ -36,15 +36,15 @@ public class F50_2940704_GridTest extends WebDriverTestCase {
 		waitResponse();
 		Assert.assertEquals(body.scrollHeight(), body.height());
 
-		click(jq("@radio:eq(0)"));
+		click(widget("@radio:eq(0)").$n("real"));
 		waitResponse();
 		Assert.assertTrue(jq("@paging").offsetTop() < body.offsetTop());
 
-		click(jq("@radio:eq(1)"));
+		click(widget("@radio:eq(1)").$n("real"));
 		waitResponse();
 		Assert.assertTrue(jq("@paging").offsetTop() > body.offsetTop());
 
-		click(jq("@radio:eq(2)"));
+		click(widget("@radio:eq(2)").$n("real"));
 		waitResponse();
 		Assert.assertEquals(body.scrollHeight(), body.height());
 		Assert.assertEquals(2, jq(".z-paging").length());

--- a/zktest/test/java/org/zkoss/zktest/zats/test2/F50_2940704_ListboxTest.java
+++ b/zktest/test/java/org/zkoss/zktest/zats/test2/F50_2940704_ListboxTest.java
@@ -36,15 +36,15 @@ public class F50_2940704_ListboxTest extends WebDriverTestCase {
 		waitResponse();
 		Assert.assertEquals(body.scrollHeight(), body.height());
 
-		click(jq("@radio:eq(0)"));
+		click(widget("@radio:eq(0)").$n("real"));
 		waitResponse();
 		Assert.assertTrue(jq("@paging").offsetTop() < body.offsetTop());
 
-		click(jq("@radio:eq(1)"));
+		click(widget("@radio:eq(1)").$n("real"));
 		waitResponse();
 		Assert.assertTrue(jq("@paging").offsetTop() > body.offsetTop());
 
-		click(jq("@radio:eq(2)"));
+		click(widget("@radio:eq(2)").$n("real"));
 		waitResponse();
 		Assert.assertEquals(body.scrollHeight(), body.height());
 		Assert.assertEquals(2, jq(".z-paging").length());

--- a/zktest/test/java/org/zkoss/zktest/zats/test2/F50_2940704_TreeTest.java
+++ b/zktest/test/java/org/zkoss/zktest/zats/test2/F50_2940704_TreeTest.java
@@ -36,15 +36,15 @@ public class F50_2940704_TreeTest extends WebDriverTestCase {
 		waitResponse();
 		Assert.assertEquals(body.scrollHeight(), body.height());
 
-		click(jq("@radio:eq(0)"));
+		click(widget("@radio:eq(0)").$n("real"));
 		waitResponse();
 		Assert.assertTrue(jq("@paging").offsetTop() < body.offsetTop());
 
-		click(jq("@radio:eq(1)"));
+		click(widget("@radio:eq(1)").$n("real"));
 		waitResponse();
 		Assert.assertTrue(jq("@paging").offsetTop() > body.offsetTop());
 
-		click(jq("@radio:eq(2)"));
+		click(widget("@radio:eq(2)").$n("real"));
 		waitResponse();
 		Assert.assertEquals(body.scrollHeight(), body.height());
 		Assert.assertEquals(2, jq(".z-paging").length());

--- a/zktest/test/java/org/zkoss/zktest/zats/test2/F50_3052761Test.java
+++ b/zktest/test/java/org/zkoss/zktest/zats/test2/F50_3052761Test.java
@@ -25,9 +25,9 @@ public class F50_3052761Test extends WebDriverTestCase {
 		connect();
 
 		String thisMonth = jq("@calendar .z-calendar-title").text();
-		jq("@calendar").eval("trigger('mousewheel', [1])");
+		eval(jq("@calendar") + ".trigger('mousewheel', [1])");
 		waitResponse();
-		jq("@calendar").eval("trigger('mousewheel', [-1])");
+		eval(jq("@calendar") + ".trigger('mousewheel', [-1])");
 		waitResponse();
 		Assert.assertEquals(thisMonth, jq("@calendar .z-calendar-title").text());
 
@@ -35,9 +35,9 @@ public class F50_3052761Test extends WebDriverTestCase {
 		waitResponse();
 
 		thisMonth = jq("@calendar:last .z-calendar-title").text();
-		jq("@calendar:last").eval("trigger('mousewheel', [-1])");
+		eval(jq("@calendar:last") + ".trigger('mousewheel', [-1])");
 		waitResponse();
-		jq("@calendar:last").eval("trigger('mousewheel', [1])");
+		eval(jq("@calendar:last") + ".trigger('mousewheel', [1])");
 		waitResponse();
 		Assert.assertEquals(thisMonth, jq("@calendar:last .z-calendar-title").text());
 	}

--- a/zktest/test/java/org/zkoss/zktest/zats/test2/F86_ZK_4059Test.java
+++ b/zktest/test/java/org/zkoss/zktest/zats/test2/F86_ZK_4059Test.java
@@ -14,6 +14,7 @@ package org.zkoss.zktest.zats.test2;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.interactions.Actions;
+
 import org.zkoss.zktest.zats.WebDriverTestCase;
 
 public class F86_ZK_4059Test extends WebDriverTestCase {
@@ -25,13 +26,13 @@ public class F86_ZK_4059Test extends WebDriverTestCase {
 		act.moveToElement(toElement(jq("$lh1")), 240, 10).click().build().perform();
 		Assert.assertTrue(jq(".z-menupopup").isVisible());
 
-		act.moveToElement(toElement(jq(".z-menuitem-checkable")), 15, 10).click().build().perform();
+		act.moveToElement(toElement(jq(".z-menuitem-checkable:visible:eq(0)")), 15, 10).click().build().perform();
 		Assert.assertTrue(jq(".z-menupopup").isVisible());
 
 		act.moveToElement(toElement(jq("$lh2")), 240, 10).click().build().perform();
 		Assert.assertTrue(jq(".z-menupopup").isVisible());
 
-		act.moveToElement(toElement(jq(".z-menuitem-checkable")), 15, 10).click().build().perform();
+		act.moveToElement(toElement(jq(".z-menuitem-checkable:visible:eq(0)")), 15, 10).click().build().perform();
 		Assert.assertFalse(jq(".z-menupopup").isVisible());
 	}
 
@@ -43,13 +44,13 @@ public class F86_ZK_4059Test extends WebDriverTestCase {
 		act.moveToElement(toElement(jq("$col1")), 240, 10).click().build().perform();
 		Assert.assertTrue(jq(".z-menupopup").isVisible());
 		
-		act.moveToElement(toElement(jq(".z-menuitem-checkable")), 15, 10).click().build().perform();
+		act.moveToElement(toElement(jq(".z-menuitem-checkable:visible:eq(0)")), 15, 10).click().build().perform();
 		Assert.assertTrue(jq(".z-menupopup").isVisible());
 		
 		act.moveToElement(toElement(jq("$col2")), 240, 10).click().build().perform();
 		Assert.assertTrue(jq(".z-menupopup").isVisible());
 		
-		act.moveToElement(toElement(jq(".z-menuitem-checkable")), 15, 10).click().build().perform();
+		act.moveToElement(toElement(jq(".z-menuitem-checkable:visible:eq(0)")), 15, 10).click().build().perform();
 		Assert.assertFalse(jq(".z-menupopup").isVisible());
 	}
 }


### PR DESCRIPTION
Upgrade to webdrivermanager 3.6.2
Fixed eval() returning nothing causes JavaScript circular exception
Add verbose log for debugging (/tmp/chromedriver.log)