### PR TITLE
revert ZK-4480: Remove JUL implementation of SLF4J to avoid leaking i…

### DIFF
--- a/zcommon/pom.xml
+++ b/zcommon/pom.xml
@@ -92,6 +92,12 @@
 			<artifactId>slf4j-api</artifactId>
 			<version>1.7.5</version>
 		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-jdk14</artifactId>
+			<version>1.7.5</version>
+			<scope>runtime</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<directory>${project.basedir}/debug</directory>

--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -18,7 +18,6 @@ ZK 9.0.1
   ZK-4475: Combobox causes overflow after ZK-4227
   ZK-4471: The line-break of message in Messagebox is wrong in IE
   ZK-4439: Widget.domListen_ binds proxied functions wrongly
-  ZK-4480: Remove JUL implementation of SLF4J to avoid leaking into consumer projects
   ZK-4467: vflex inside closed groupbox has no effect
   ZK-4465: vflex inside drawer has no effect
   ZK-4408: notification cause parent/children issues after ZK-4130


### PR DESCRIPTION
…nto consumer projects