### PR TITLE
ZK-4468: ImportHandler fails to import correct class after cached "No…

### DIFF
--- a/zel/src/org/zkoss/zel/ImportHandler.java
+++ b/zel/src/org/zkoss/zel/ImportHandler.java
@@ -123,7 +123,7 @@ public class ImportHandler {
         String simpleName = clazz.getSimpleName();
         Class<?> conflict = clazzes.get(simpleName);
 
-        if (conflict == null) {
+        if (conflict == null || NotFound.class.equals(conflict)) {
             // No conflict - add it
             clazzes.put(simpleName, clazz);
         } else {

--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -35,6 +35,7 @@ ZK 9.0.1
   ZK-4513: listbox issues with invalidatePartial
   ZK-4409: combobutton misaligned vertically
   ZK-4383: Combobox losing input characters
+  ZK-4468: ImportHandler fails to import correct class after cached "NotFound"
 
 * Upgrade Notes
 

--- a/zktest/test/java/org/zkoss/zktest/zats/test2/B90_ZK_4468Test.java
+++ b/zktest/test/java/org/zkoss/zktest/zats/test2/B90_ZK_4468Test.java
@@ -1,0 +1,37 @@
+/* B90_ZK_4468Test.java
+
+	Purpose:
+		
+	Description:
+		
+	History:
+		Tue Mar 03 14:56:18 CST 2020, Created by rudyhuang
+
+Copyright (C) 2020 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.zkoss.zel.ImportHandler;
+
+/**
+ * @author rudyhuang
+ */
+public class B90_ZK_4468Test {
+	@Test
+	public void testReImportAfterFailedResolve() {
+		ImportHandler importHandler = ImportHandler.getImportHandler();
+		String simpleName = B90_ZK_4468Test.class.getSimpleName();
+		Assert.assertNull(
+				"initially not imported class should resolved to null",
+				importHandler.resolveClass(simpleName));
+
+		importHandler.importClass(B90_ZK_4468Test.class.getName());
+		Assert.assertEquals(
+				"after importing should be resolved",
+				B90_ZK_4468Test.class,
+				importHandler.resolveClass(simpleName));
+	}
+}


### PR DESCRIPTION
…tFound"