### PR TITLE
refine ZK-4598: Menubar arrow keys navigation

### DIFF
--- a/zktest/src/archive/wcag/menubar.zul
+++ b/zktest/src/archive/wcag/menubar.zul
@@ -20,11 +20,11 @@ Copyright (C) 2020 Potix Corporation. All Rights Reserved.
     </n:header>
     <n:main>
         <menubar width="500px" scrollable="true">
-            <menuitem label="Menu A"/>
+            <menuitem label="Menu A" onClick='Clients.log(self.label)'/>
             <menuseparator />
             <menu label="Menu B">
                 <menupopup>
-                    <menuitem iconSclass="z-icon-home" label="Menu BA"/>
+                    <menuitem iconSclass="z-icon-home" label="Menu BA" onClick='Clients.log(self.label)'/>
                     <menuitem image="/img/live.gif" label="Menu BB"/>
                     <menu label="Menu BC">
                         <menupopup>
@@ -36,19 +36,24 @@ Copyright (C) 2020 Potix Corporation. All Rights Reserved.
             </menu>
             <menuitem disabled="true" label="Menu E"/>
             <menuitem label="Menu Foooooooooooooooooooooooooooooo"/>
-            <menuitem label="Menu Goooooooooooooooooooooooooooooo"/>
+            <menu label="Menu G">
+                <menupopup>
+                    <menuitem label="Menu G1"/>
+                </menupopup>
+            </menu>
+            <menuitem label="Menu Hoooooooooooooooooooooooooooooo"/>
         </menubar>
 
         <menubar orient="vertical" hflex="min">
-            <menuitem label="Menu A"/>
+            <menuitem label="Menu A" onClick='Clients.log(self.label)'/>
             <menuseparator />
             <menu label="Menu B">
                 <menupopup>
-                    <menuitem iconSclass="z-icon-home" label="Menu BA"/>
+                    <menuitem iconSclass="z-icon-home" label="Menu BA" onClick='Clients.log(self.label)'/>
                     <menuitem image="/img/live.gif" label="Menu BB"/>
                     <menu label="Menu BC">
                         <menupopup>
-                            <menuitem checkmark="true" checked="true" autocheck="true" label="Menu C"/>
+                            <menuitem checkmark="true" checked="true" autocheck="true" label="Menu C (autocheck)"/>
                             <menuitem checkmark="true" checked="false" label="Menu D"/>
                         </menupopup>
                     </menu>

--- a/zul/src/archive/web/js/zul/menu/Menu.js
+++ b/zul/src/archive/web/js/zul/menu/Menu.js
@@ -306,16 +306,8 @@ zul.menu.Menu = zk.$extends(zul.LabelImageWidget, {
 				}
 				evt.stop();
 				break;
-			case 37: //LEFT
-			case 39: //RIGHT
-				// LEFT: 1. jump to the previous menu if any, otherwise, jump to the last one
-				// RIGHT: 1. jump to the next menu if any, otherwise, jump to the first one
-				var target = keyCode == 37 ? this._getPrevVisibleMenu() : this._getNextVisibleMenu();
-				if (target)
-					target.focus();
-				evt.stop();
-				break;
 			case 13: //ENTER
+			case 32: //SPACE
 				// 1. toggle the open/close status for the menupopup, if any.
 				if (this.menupopup)
 					_doClick(this, evt);
@@ -481,7 +473,7 @@ zul.menu.Menu = zk.$extends(zul.LabelImageWidget, {
 		if (this.isTopmost()) {
 			var bar = this.getMenubar();
 			if (bar)
-				return 'vertical' == bar.getOrient();
+				return bar.isVertical();
 		}
 		return false;
 	}

--- a/zul/src/archive/web/js/zul/menu/Menupopup.js
+++ b/zul/src/archive/web/js/zul/menu/Menupopup.js
@@ -84,7 +84,10 @@ it will be useful, but WITHOUT ANY WARRANTY.
 		var pp = menu.menupopup;
 		if (pp) {
 			pp._shallClose = false;
-			if (!pp.isOpen()) pp.open();
+			if (!pp.isOpen()) {
+				menu.focus();
+				pp.open();
+			}
 		}
 		menu.$class._addActive(menu);
 		zWatch.fire('onFloatUp', menu); //notify all
@@ -276,7 +279,7 @@ zul.menu.Menupopup = zk.$extends(zul.wgt.Popup, {
 	},
 	onShow: function () {
 		this.zsync();
-		var anc = this.$n('a');
+		var anc = this.getAnchor_();
 		if (anc) {
 			if (zk(anc).isRealVisible()) {
 				anc.focus();
@@ -348,8 +351,7 @@ zul.menu.Menupopup = zk.$extends(zul.wgt.Popup, {
 				menu.$class._addActive(menu);
 				var pp = menu.parent;
 				if (pp) {
-					var anc = pp.$n('a');
-					if (anc) anc.focus();
+					pp.focus();
 					pp._curIndex = _indexOfVisibleMenu(pp, menu);
 				}
 			} else {
@@ -392,8 +394,7 @@ zul.menu.Menupopup = zk.$extends(zul.wgt.Popup, {
 						menu.$class._addActive(menu);
 						var pp = menu.parent;
 						if (pp) {
-							var anc = pp.$n('a');
-							if (anc) anc.focus();
+							pp.focus();
 						}
 					}
 				}
@@ -414,8 +415,7 @@ zul.menu.Menupopup = zk.$extends(zul.wgt.Popup, {
 						menu.$class._addActive(menu);
 						var pp = menu.parent;
 						if (pp) {
-							var anc = pp.$n('a');
-							if (anc) anc.focus();
+							pp.focus();
 						}
 					}
 				}
@@ -435,6 +435,13 @@ zul.menu.Menupopup = zk.$extends(zul.wgt.Popup, {
 		if (keyCode != 9 && keyCode != 27) // TAB && ESC
 			evt.stop(); // Bug ZK-442
 		this.$supers('doKeyDown_', arguments);
+	},
+	doClick_: function (evt) {
+		// Prevent from closing the popup if being triggered by space key.
+		// https://bugzilla.mozilla.org/show_bug.cgi?id=1220143
+		if (evt.domTarget == this.getAnchor_())
+			evt.stop();
+		this.$supers('doClick_', arguments);
 	},
 	/** Returns the {@link Menubar} that contains this menuitem, or null if not available.
 	 * @return zul.menu.Menubar
@@ -488,6 +495,16 @@ zul.menu.Menupopup = zk.$extends(zul.wgt.Popup, {
 				if (target) target.$class._addActive(target);
 			}
 		}
+	},
+	// internal use only.
+	getAnchor_: function () {
+		return this.$n('a');
+	},
+	focus_: function (timeout) {
+		if (zk(this.getAnchor_()).focus(timeout)) {
+			return true;
+		}
+		return this.$supers('focus_', arguments);
 	}
 }, {
 	_rmActive: function (wgt) {


### PR DESCRIPTION
Open Next Menupopup, move focus
Regain focus to the root menu while the menuitem is activated
Press space to open menupopup
Open menupopup, focus on the first menuitem