### PR TITLE
refine ZK-4598: no feedback for expand/collapse on detail/group && so…

### DIFF
--- a/zktest/src/archive/wcag/grid.zul
+++ b/zktest/src/archive/wcag/grid.zul
@@ -30,9 +30,9 @@ Copyright (C) 2020 Potix Corporation. All Rights Reserved.
 		<button label="Simple Grid" />
 		<grid>
 			<auxhead>
-				<auxheader label="column 1" colspan="1"/>
-				<auxheader label="column 2" colspan="1"/>
-				<auxheader label="column 3,4" colspan="2"/>
+				<auxheader label="apple" colspan="1"/>
+				<auxheader label="banana" colspan="1"/>
+				<auxheader label="lemon" colspan="2"/>
 			</auxhead>
 			<columns>
 				<column hflex="5">Language</column>
@@ -56,7 +56,7 @@ Copyright (C) 2020 Potix Corporation. All Rights Reserved.
 				<row>
 					<cell>Italian (it)</cell>
 					<cell>Matteo Barbieri</cell>
-					<cell>iso-8859-1</cell>
+					<label value="iso-8859-1"/>
 					<cell><textbox ca:aria-label="textbox"/></cell>
 				</row>
 			</rows>

--- a/zul/src/archive/web/js/zul/grid/Row.js
+++ b/zul/src/archive/web/js/zul/grid/Row.js
@@ -179,7 +179,7 @@ zul.grid.Row = zk.$extends(zul.Widget, {
 			child._headerVisible = opts.visible;
 		else {
 			out.push('<td id="', child.uuid, '-chdextr"',
-				this._childAttrs(child, opts.index), ' tabindex="-1"><div id="', child.uuid,
+				this._childAttrs(child, opts.index), ' tabindex="-1" role="gridcell"><div id="', child.uuid,
 				'-cell" class="', opts.zclass, '-content">');
 		}
 		child.redraw(out);

--- a/zul/src/archive/web/js/zul/grid/mold/row.js
+++ b/zul/src/archive/web/js/zul/grid/mold/row.js
@@ -13,7 +13,7 @@ This program is distributed under LGPL Version 2.1 in the hope that
 it will be useful, but WITHOUT ANY WARRANTY.
 */
 function (out) {
-	out.push('<tr', this.domAttrs_(), ' role="row">');
+	out.push('<tr', this.domAttrs_(), '>');
 	var zcls = this.getZclass(),
 		grid = this.getGrid(),
 		head = grid.getHeadWidget();


### PR DESCRIPTION
…rting on header, footer is annonced outside of the grid table, Group speech "text frame" only (Firefox).