### PR TITLE
ZK-4453: onError fires again when valid value is entered

### DIFF
--- a/zktest/src/archive/test2/B95-ZK-4453.zul
+++ b/zktest/src/archive/test2/B95-ZK-4453.zul
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+B95-ZK-4453.zul
+
+	Purpose:
+		
+	Description:
+		
+	History:
+		Tue Aug 11 12:23:16 CST 2020, Created by rudyhuang
+
+Copyright (C) 2020 Potix Corporation. All Rights Reserved.
+
+-->
+<zk>
+    <label multiline="true">
+        1. Input -1 to trigger an error.
+        2. Correct by entering 1.
+        3. No onError event should be triggered again. (Since a patch is applied)
+    </label>
+    <script><![CDATA[
+    zk.afterLoad("zul.inp", function () {
+        var _xInputWidget = {};
+        zk.override(zul.inp.InputWidget.prototype, _xInputWidget, {
+            _sendClearingErrorEvent: function (val) {
+                // leave it blank for not sending a clearing ErrorEvent
+            }
+        });
+    });
+    ]]>
+    </script>
+    <intbox constraint="no negative"
+            onError='Clients.log("error: " + event + ", message: " + event.message)'/>
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -2790,6 +2790,7 @@ B90-ZK-4431.zul=A,E,Multislider
 ##zats##B95-ZK-4476.zul=A,E,css,flex,minFlex
 ##zats##B95-ZK-4633.zul=A,E,Rangeslider,Multislider,disabled
 ##zats##B95-ZK-4637.zul=A,E,Searchbox,disabled
+##zats##B95-ZK-4453.zul=A,E,InputWidget,onError
 
 ##
 # Features - 3.0.x version

--- a/zktest/test/java/org/zkoss/zktest/zats/test2/B95_ZK_4453Test.java
+++ b/zktest/test/java/org/zkoss/zktest/zats/test2/B95_ZK_4453Test.java
@@ -1,0 +1,43 @@
+/* B95_ZK_4453Test.java
+
+	Purpose:
+		
+	Description:
+		
+	History:
+		Tue Aug 11 12:30:04 CST 2020, Created by rudyhuang
+
+Copyright (C) 2020 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.Keys;
+
+import org.zkoss.zktest.zats.WebDriverTestCase;
+import org.zkoss.zktest.zats.ztl.JQuery;
+
+/**
+ * @author rudyhuang
+ */
+public class B95_ZK_4453Test extends WebDriverTestCase {
+	@Test
+	public void test() {
+		connect();
+
+		JQuery intbox = jq("@intbox");
+		click(intbox);
+		waitResponse();
+		sendKeys(intbox, "-1", Keys.TAB);
+		waitResponse();
+		Assert.assertTrue(getZKLog().startsWith("error: "));
+		closeZKLog();
+
+		click(intbox);
+		waitResponse();
+		sendKeys(intbox, Keys.BACK_SPACE, Keys.BACK_SPACE, "1", Keys.TAB);
+		waitResponse();
+		Assert.assertFalse(isZKLogAvailable());
+	}
+}

--- a/zul/src/archive/web/js/zul/inp/InputWidget.js
+++ b/zul/src/archive/web/js/zul/inp/InputWidget.js
@@ -690,12 +690,16 @@ zul.inp.InputWidget = zk.$extends(zul.Widget, {
 				}
 				this._reVald = false;
 				if (em)
-					this.fire('onError', {value: val});
+					this._sendClearingErrorEvent(val);
 			}
 			return {value: val};
 		} finally {
 			zul.inp.validating = false;
 		}
+	},
+	_sendClearingErrorEvent: function (val) {
+		// ZK-4453 for easier overriding this behavior
+		this.fire('onError', {value: val});
 	},
 	_shallIgnore: function (evt, keys) {
 		// ZK-1736 add metakey on mac


### PR DESCRIPTION
Not actually fix it, but extracting a method for easier modification.