### PR TITLE
revert ZK-4560: toolbarbutton apply min-height workaround

### DIFF
--- a/zul/src/archive/web/js/zul/wgt/less/toolbar.less
+++ b/zul/src/archive/web/js/zul/wgt/less/toolbar.less
@@ -127,8 +127,6 @@
 	border: @buttonBorderWidth solid transparent;
 	background-color: @toolbarButtonBackgroundColor;
 	padding: @toolbarButtonPadding;
-	height: 1px; // https://stackoverflow.com/a/21836870
-	min-height: @inputHeight;
 
 	// A hack to make the content vertical centering, see ZK-4532
 	&:before {


### PR DESCRIPTION
it causes the content height not expandable