### PR TITLE
ZK-4766: splitter aria-valuenow /-valuetext don't update on collapse

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -98,6 +98,11 @@ ZK 9.5.1
   ZK-4619: The radiogroup of cloned radio is not updated
   ZK-4759: CSS Flex should not reset when resizing
   ZK-4765: splitter/splitlayout freezes after click on disabled collapse button
+  ZK-4766: splitter aria-valuenow /-valuetext don't update on collapse
+  ZK-4767: splitter aria-controls wrong for collapse="after"
+  ZK-4768: splitlayout aria-controls wrong for collapse="after"
+  ZK-4769: splitter aria-valuenow reversed for collapse="after"
+  ZK-4770: splitlayout aria-valuenow reversed collapse="after"
 
 * Upgrade Notes
   + Now the "zk.edge" is true only in the new Edge (Chromium-based), and we provide zk.edge_legacy for compatibility.

--- a/zktest/src/archive/test2/B95-ZK-4766.zul
+++ b/zktest/src/archive/test2/B95-ZK-4766.zul
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+B95-ZK-4766.zul
+
+	Purpose:
+		
+	Description:
+		
+	History:
+		Wed Jan 13 15:29:38 CST 2021, Created by jameschu
+
+Copyright (C) 2021 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+	<label multiline="true">
+		ZK-4766: click the splitter middle buttons, the aria-valuenow/aria-valuetext should be changed
+		ZK-4767: The aria-controls value of 'collapse="after"' should be the "next" container
+		ZK-4769: Click the second middle of splitter button, the aria-valuenow/aria-valuetext of 'collapse="after"' should be reversed (0)
+	</label>
+	<separator />
+	<hbox height="100px" width="100%">
+		<div>
+			left side <textbox/>
+		</div>
+		<splitter collapse="before"/>
+		<div>
+			right side <textbox/>
+		</div>
+	</hbox>
+	<hbox height="100px" width="100%">
+		<div>
+			left side <textbox/>
+		</div>
+		<splitter id="after1" collapse="after"/>
+		<div id="right1">
+			right side <textbox/>
+		</div>
+	</hbox>
+	<separator />
+	<label multiline="true">
+		ZK-4768: The aria-controls value of 'collapse="after"' should be the "next" container
+		ZK-4770: Click the second middle of splitter button, the aria-valuenow/aria-valuetext of 'collapse="after"' should be reversed (0)
+	</label>
+	<separator />
+	<splitlayout height="200px" orient="horizontal" widths="200,200">
+		<div />
+		<div />
+	</splitlayout>
+	<splitlayout id="after2" height="200px" orient="horizontal" collapse="after" widths="200,200">
+		<div />
+		<div id="right2"/>
+	</splitlayout>
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -2907,6 +2907,7 @@ B90-ZK-4431.zul=A,E,Multislider
 ##zats##B95-ZK-4619.zul=A,E,Radiogroup,Clone
 ##zats##B95-ZK-4759.zul=A,E,Flex,resize,BeforeSize
 ##zats##B95-ZK-4765.zul=A,E,Splitter,drag,collapsed,Splitlayout
+##zats##B95-ZK-4766.zul=A,E,WCAG,splitter,Splitlayout
 
 ##
 # Features - 3.0.x version

--- a/zktest/test/java/org/zkoss/zktest/zats/test2/B95_ZK_4766Test.java
+++ b/zktest/test/java/org/zkoss/zktest/zats/test2/B95_ZK_4766Test.java
@@ -1,0 +1,52 @@
+/* B95_ZK_4766Test.java
+
+	Purpose:
+		
+	Description:
+		
+	History:
+		Wed Jan 13 15:29:38 CST 2021, Created by jameschu
+
+Copyright (C) 2021 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.zkoss.zktest.zats.WebDriverTestCase;
+import org.zkoss.zktest.zats.wcag.WcagTestOnly;
+import org.zkoss.zktest.zats.ztl.JQuery;
+
+/**
+ * @author jameschu
+ */
+
+@Category(WcagTestOnly.class)
+public class B95_ZK_4766Test extends WebDriverTestCase {
+
+	@Test
+	public void test() throws Exception {
+		connect();
+		waitResponse();
+		JQuery jqAfter1 = jq("$after1");
+		JQuery jqAfter2 = jq("$after2");
+		//ZK-4767
+		Assert.assertEquals(jq("$right1").parent().attr("id"), jqAfter1.attr("aria-controls"));
+		JQuery jqSplitter = jq(jqAfter2.toWidget().$n("splitter"));
+
+		//ZK-4768
+		Assert.assertEquals(jq("$right2").parent().attr("id"), jqSplitter.attr("aria-controls"));
+
+		//ZK-4766, ZK-4769
+		click(jqAfter1.toWidget().$n("btn"));
+		Assert.assertEquals("0", jqAfter1.attr("aria-valuenow"));
+		Assert.assertEquals("0", jqAfter1.attr("aria-valuetext"));
+
+		//ZK-4770
+		click(jqAfter2.toWidget().$n("splitter-btn"));
+		Assert.assertEquals("0", jqSplitter.attr("aria-valuenow"));
+		Assert.assertEquals("0", jqSplitter.attr("aria-valuetext"));
+	}
+}


### PR DESCRIPTION
ZK-4767: splitter aria-controls wrong for collapse="after"
ZK-4768: splitlayout aria-controls wrong for collapse="after"
ZK-4769: splitter aria-valuenow reversed for collapse="after"
ZK-4770: splitlayout aria-valuenow reversed collapse="after"