### PR TITLE
refine TestCafe in iPad Safari uses desktop mode (mouse not touch) by…

### DIFF
--- a/zk/src/archive/web/js/zk/domtouch.js
+++ b/zk/src/archive/web/js/zk/domtouch.js
@@ -58,6 +58,13 @@ function _toMouseEvent(event, changedTouch) {
 	case 'touchmove':
 		var ele = document.elementFromPoint(changedTouch.clientX,changedTouch.clientY);
 		return (ele && _createJQEvent(ele, 'mousemove', 0, changedTouch)) || null;
+	case 'pointerdown':
+		return _createJQEvent(event.target, 'mousedown', event.button, event.originalEvent);
+	case 'pointerup':
+		return _createJQEvent(event.target, 'mouseup', event.button, event.originalEvent);
+	case 'pointermove':
+		var target = event.target;
+		return (target && _createJQEvent(target, 'mousemove', event.button, event.originalEvent)) || null;
 	}
 	return event;
 }
@@ -82,10 +89,11 @@ function delegateEventFunc (event) {
 	if (evt = _toMouseEvent(event, changedTouches))
 		_doEvt(event.type, event, evt);
 }
+var pointerEventAvailable = !!window.PointerEvent; // Introduced since iOS 13.1
 zk.copy(zjq.eventTypes, {
-	zmousedown: 'touchstart',
-	zmouseup: 'touchend',
-	zmousemove: 'touchmove'
+	zmousedown: pointerEventAvailable ? 'pointerdown' : 'touchstart',
+	zmouseup: pointerEventAvailable ? 'pointerup' : 'touchend',
+	zmousemove: pointerEventAvailable ? 'pointermove' : 'touchmove'
 });
 function _storeEventFunction(elem, type, data, fn) {
 	var eventFuncs = jq.data(elem, 'zk_eventFuncs'),

--- a/zktest/src/archive/test2/B90-ZK-4439.js
+++ b/zktest/src/archive/test2/B90-ZK-4439.js
@@ -1,12 +1,12 @@
 var MyComp4439 = zk.$extends(zul.Widget, {
 	bind_: function () {
 		this.$supers('bind_', arguments);
-		var evtName = zk.mobile ? 'onTouchstart' : 'onClick';
+		var evtName = zk.mobile ? 'onZMouseDown' : 'onClick';
 		this.domListen_(this.$n('btnA'), evtName, this.proxy(this._doClickA))
 			.domListen_(this.$n('btnB'), evtName, this.proxy(this._doClickB));
 	},
 	unbind_: function () {
-		var evtName = zk.mobile ? 'onTouchstart' : 'onClick';
+		var evtName = zk.mobile ? 'onZMouseDown' : 'onClick';
 		this.domUnlisten_(this.$n('btnB'), evtName, this.proxy(this._doClickB))
 			.domUnlisten_(this.$n('btnA'), evtName, this.proxy(this._doClickA));
 		this.$supers('unbind_', arguments);


### PR DESCRIPTION
… default

PointerEvent was supported since iOS 13.1, so either mouse or touch can be handled