### PR TITLE
ZK-4762: listbox with frozen columns cannot show all headers under non-100% zoom level(non-smooth)

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -2,6 +2,7 @@ ZK 9.6.0
 * Features
 
 * Bugs
+  ZK-4762: listbox with frozen columns cannot show all headers under non-100% zoom level(non-smooth)
 
 * Upgrade Notes
 

--- a/zktest/src/archive/test2/B96-ZK-4762.zul
+++ b/zktest/src/archive/test2/B96-ZK-4762.zul
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+B96-ZK-4762.zul
+
+	Purpose:
+
+	Description:
+
+	History:
+		Mon Jan 18 17:28:04 CST 2021, Created by katherinelin
+
+Copyright (C) 2021 Potix Corporation. All Rights Reserved.
+
+-->
+<zk>
+	<label multiline="true">
+		1. zoom to 75%
+		2. scroll to the right-most column
+		3. scroll to the left-most column
+		4. the 3rd and 4th columns should be visible
+	</label>
+	<custom-attributes org.zkoss.zul.frozen.smooth="false"/>
+	<listbox id="listbox" height="300px" width="500px">
+
+		<frozen columns="2"/>
+		<listhead sizable="true">
+			<listheader label="Id" width="150px"   />
+			<listheader label="Item Id" width="150px"   />
+			<listheader label="Item Code" width="70px"  />
+			<listheader label="Item Description" width="300px"   />
+			<listheader label="Created Date" width="150px" />
+			<listheader label="Created By" width="150px"  />
+			<listheader label="Terminated Date" width="150px" />
+			<listheader label="Terminated By" width="150px" />
+			<listheader label="UOM" width="150px"   />
+			<listheader label="Composition" width="150px" />
+			<listheader label="Default" width="150px"  />
+			<listheader label="Composition" width="150px" />
+			<listheader label="Composition" width="150px" />
+			<listheader label="Composition" width="150px" />
+			<listheader label="Composition" width="150px" />
+			<listheader label="Composition" width="150px" />
+			<listheader label="Composition" width="150px" />
+		</listhead>
+		<listitem>
+			<listcell label="cell"/>
+			<listcell label="cell"/>
+			<listcell label="cell"/>
+			<listcell label="cell"/>
+			<listcell label="cell"/>
+			<listcell label="cell"/>
+			<listcell label="cell"/>
+			<listcell label="cell"/>
+			<listcell label="cell"/>
+			<listcell label="cell"/>
+			<listcell label="cell"/>
+			<listcell label="cell"/>
+			<listcell label="cell"/>
+			<listcell label="cell"/>
+			<listcell label="cell"/>
+			<listcell label="cell"/>
+			<listcell label="aaaaaaaaa"/>
+		</listitem>
+		<listitem>
+			<listcell label="cell"/>
+			<listcell label="cell"/>
+			<listcell label="cell"/>
+			<listcell label="cell"/>
+			<listcell label="cell"/>
+			<listcell label="cell"/>
+			<listcell label="cell"/>
+			<listcell label="cell"/>
+			<listcell label="cell"/>
+			<listcell label="cell"/>
+			<listcell label="cell"/>
+			<listcell label="cell"/>
+			<listcell label="cell"/>
+			<listcell label="cell"/>
+			<listcell label="cell"/>
+			<listcell label="cell"/>
+			<listcell label="cell"/>
+		</listitem>
+	</listbox>
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -2923,6 +2923,7 @@ B90-ZK-4431.zul=A,E,Multislider
 ##manually##B95-ZK-4786.zul=A,E,MVVM,MemoryLeak,Databinding
 
 ## B96
+##manually##B96-ZK-4762.zul=A,E,Grid,Frozen,scroll
 
 ##
 # Features - 3.0.x version

--- a/zul/src/archive/web/js/zul/mesh/Frozen.js
+++ b/zul/src/archive/web/js/zul/mesh/Frozen.js
@@ -347,7 +347,8 @@ zul.mesh.Frozen = zk.$extends(zul.Widget, {
 							: 0,
 						nativebar = mesh._nativebar;
 					// ZK-2071: nativebar behavior should be same as fakebar
-					if (force || (wd < 1)) {
+					// ZK-4762: cellWidth should update while scroll into view
+					if (force || (wd < 2)) {
 						cellWidth = hdWgt._origWd || jq.px(wd);
 						// ZK-2772: consider faker's width first for layout consistent
 						// if the column is visible.


### PR DESCRIPTION
ZK-4762: listbox with frozen columns cannot show all headers under non-100% zoom level(non-smooth)