### PR TITLE
refine ZK-4760: default error message box hard coded width (too small)

### DIFF
--- a/zul/src/archive/web/js/zul/dom.js
+++ b/zul/src/archive/web/js/zul/dom.js
@@ -73,6 +73,7 @@ it will be useful, but WITHOUT ANY WARRANTY.
 				var wnd = new zul.wnd.Window({
 					id: 'aualert',
 					closable: true,
+					width: '250pt',
 					sclass: 'z-messagebox-window',
 					title: opts.title || zk.appName,
 					border: 'normal',

--- a/zul/src/archive/web/js/zul/wnd/less/window.less
+++ b/zul/src/archive/web/js/zul/wnd/less/window.less
@@ -116,8 +116,6 @@
 .z-messagebox {
 	&-window {
 		padding: @messageboxWindowPadding;
-		min-width: 250px;
-		max-width: 100vw;
 	}
 
 	&-window .z-window-header {
@@ -126,6 +124,7 @@
 
 	&-window .z-window-content {
 		padding: @messageboxInnerPadding;
+		overflow: auto;
 	}
 
 	&-window .z-separator {
@@ -134,6 +133,8 @@
 
 	&-buttons {
 		text-align: right;
+		left: 0;
+		position: sticky;
 		& > * {
 			margin-left: @messageboxButtonsMarginLeft;
 		}


### PR DESCRIPTION
refine ZK-4760: default error message box hard coded width (too small)