### PR TITLE
ZK-4814: WCAG splitter/splitlayout not updating (aria-valuenow/-value…

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -5,6 +5,7 @@ ZK 9.6.0
   ZK-4762: listbox with frozen columns cannot show all headers under non-100% zoom level(non-smooth)
   ZK-4813: WCAG splitter/splitlayout (collapse="after")
   ZK-3563: Children binding causes load binding to stop firing
+  ZK-4814: WCAG splitter/splitlayout not updating (aria-valuenow/-valuelabel) when using mouse
 
 * Upgrade Notes
 

--- a/zktest/src/archive/test2/B96-ZK-4814.zul
+++ b/zktest/src/archive/test2/B96-ZK-4814.zul
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+B96-ZK-4813.zul
+
+	Purpose:
+		
+	Description:
+		
+	History:
+		Tue Mar 09 12:50:22 CST 2021, Created by jameschu
+
+Copyright (C) 2021 Potix Corporation. All Rights Reserved.
+
+-->
+<zk>
+	<label>
+		Drag/Drop the splitter, the valuenow should change
+	</label>
+	<hbox height="100px" width="100%">
+		<div>
+			left side
+		</div>
+		<splitter/>
+		<div>
+			right side
+		</div>
+	</hbox>
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -2926,6 +2926,7 @@ B90-ZK-4431.zul=A,E,Multislider
 ##manually##B96-ZK-4762.zul=A,E,Grid,Frozen,scroll
 ##zats##B96-ZK-4813.zul=A,E,Splitlayout,WCAG,splitter
 ##zats##B96-ZK-3563.zul=A,M,ChildrenBinding,MVVM,Databinding
+##zats##B96-ZK-4814.zul=A,E,WCAG,Splitter,Dragdrop
 
 ##
 # Features - 3.0.x version

--- a/zktest/test/java/org/zkoss/zktest/zats/test2/B96_ZK_4814Test.java
+++ b/zktest/test/java/org/zkoss/zktest/zats/test2/B96_ZK_4814Test.java
@@ -1,0 +1,39 @@
+/* B96_ZK_4814Test.java
+
+	Purpose:
+		
+	Description:
+		
+	History:
+		Tue Mar 09 12:50:22 CST 2021, Created by jameschu
+
+Copyright (C) 2021 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.zkoss.zktest.zats.WebDriverTestCase;
+import org.zkoss.zktest.zats.wcag.WcagTestOnly;
+import org.zkoss.zktest.zats.ztl.JQuery;
+
+/**
+ * @author jameschu
+ */
+
+@Category(WcagTestOnly.class)
+public class B96_ZK_4814Test extends WebDriverTestCase {
+
+	@Test
+	public void test() throws Exception {
+		connect();
+		waitResponse();
+		JQuery jqSplitter = jq(".z-splitter");
+		String valuenow = jqSplitter.attr("aria-valuenow");
+		dragdropTo(jqSplitter, 3, 0, 20, 0);
+		waitResponse();
+		Assert.assertNotEquals(jqSplitter.attr("aria-valuenow"), valuenow);
+	}
+}


### PR DESCRIPTION
…label) when using mouse