### PR TITLE
refine ZK-4760: default error message box hard coded width (too small)

### DIFF
--- a/zktest/test/java/org/zkoss/zktest/zats/test2/B95_ZK_4760Test.java
+++ b/zktest/test/java/org/zkoss/zktest/zats/test2/B95_ZK_4760Test.java
@@ -22,22 +22,22 @@ public class B95_ZK_4760Test extends WebDriverTestCase {
 		connect();
 		click(jq("@button:eq(0)"));
 		waitResponse();
-		Assert.assertTrue(Boolean.valueOf(zk(jq(".z-window-content")).eval("hasHScroll()")));
+		Assert.assertTrue(Boolean.valueOf(zk(jq(".z-messagebox-viewport")).eval("hasHScroll()")));
 		click(jq("@button:eq(6)"));
 
 		click(jq("@button:eq(1)"));
 		waitResponse();
-		Assert.assertFalse(Boolean.valueOf(zk(jq(".z-window-content")).eval("hasHScroll()")));
+		Assert.assertFalse(Boolean.valueOf(zk(jq(".z-messagebox-viewport")).eval("hasHScroll()")));
 		click(jq("@button:eq(6)"));
 
 		click(jq("@button:eq(2)"));
 		waitResponse();
-		Assert.assertFalse(Boolean.valueOf(zk(jq(".z-window-content")).eval("hasHScroll()")));
+		Assert.assertFalse(Boolean.valueOf(zk(jq(".z-messagebox-viewport")).eval("hasHScroll()")));
 		click(jq(".z-messagebox-button"));
 
 		click(jq("@button:eq(3)"));
 		waitResponse();
-		Assert.assertFalse(Boolean.valueOf(zk(jq(".z-window-content")).eval("hasHScroll()")));
+		Assert.assertTrue(Boolean.valueOf(zk(jq(".z-messagebox-viewport")).eval("hasHScroll()")));
 		click(jq(".z-messagebox-button"));
 
 		click(jq("@button:eq(4)"));
@@ -47,7 +47,7 @@ public class B95_ZK_4760Test extends WebDriverTestCase {
 
 		click(jq("@button:eq(5)"));
 		waitResponse();
-		Assert.assertFalse(Boolean.valueOf(zk(jq(".z-window-content")).eval("hasHScroll()")));
+		Assert.assertTrue(Boolean.valueOf(zk(jq(".z-messagebox-viewport")).eval("hasHScroll()")));
 		click(jq(".z-messagebox-button"));
 	}
 }


### PR DESCRIPTION
refine ZK-4760: default error message box hard coded width (too small)