### PR TITLE
ZK-4701: chosenbox initial width too short to display emptyMessage

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -31,6 +31,7 @@ ZK 9.6.0
   ZK-4820: Chosenbox aria-activedescendant out of sync (za11y.jar)
   ZK-4763: Radiogroup selectedIndex error after radio moved
   ZK-4825: Websockets NPE during encodeURL
+  ZK-4701: chosenbox initial width too short to display emptyMessage
 
 * Upgrade Notes
   + The default desktop ID generator was replaced by a more secured one.

--- a/zktest/src/archive/test2/B96-ZK-4701.zul
+++ b/zktest/src/archive/test2/B96-ZK-4701.zul
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+B96-ZK-4701.zul
+
+	Purpose:
+
+	Description:
+
+	History:
+		Mon Mar 22 18:16:35 CST 2021, Created by katherinelin
+
+Copyright (C) 2021 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+	<chosenbox emptyMessage="aaaaa" />
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -2944,6 +2944,7 @@ B90-ZK-4431.zul=A,E,Multislider
 ##zats##B96-ZK-4820.zul=A,E,WCAG,Chosenbox
 ##zats##B96-ZK-4763.zul=A,E,Radio,Radiogroup
 ##manually##B96-ZK-4825.zul=A,E,WebSocket,encodeURL,ServletContext,NPE
+##zats##B96-ZK-4701.zul=A,E,Chosenbox,emptyMessage
 
 ##
 # Features - 3.0.x version

--- a/zktest/test/java/org/zkoss/zktest/zats/test2/B96_ZK_4701Test.java
+++ b/zktest/test/java/org/zkoss/zktest/zats/test2/B96_ZK_4701Test.java
@@ -1,0 +1,28 @@
+/* B96_ZK_4701Test.java
+
+	Purpose:
+		
+	Description:
+		
+	History:
+		Tue Mar 23 09:43:02 CST 2021, Created by katherinelin
+
+Copyright (C) 2021 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import org.hamcrest.MatcherAssert;
+import org.junit.Test;
+import org.zkoss.zktest.zats.WebDriverTestCase;
+import static org.hamcrest.Matchers.lessThan;
+
+import static org.hamcrest.Matchers.greaterThan;
+
+public class B96_ZK_4701Test extends WebDriverTestCase {
+	@Test
+	public void test() {
+		connect();
+		MatcherAssert.assertThat(
+			jq(".z-chosenbox-textcontent").width(), lessThan(jq(".z-chosenbox-input").width()));
+	}
+}


### PR DESCRIPTION
ZK-4701: chosenbox initial width too short to display emptyMessage