### PR TITLE
ZK-4811: menubar autodrop="false" has no effect on nested submenus

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -32,6 +32,7 @@ ZK 9.6.0
   ZK-4763: Radiogroup selectedIndex error after radio moved
   ZK-4825: Websockets NPE during encodeURL
   ZK-4701: chosenbox initial width too short to display emptyMessage
+  ZK-4811: menubar autodrop="false" has no effect on nested submenus
 
 * Upgrade Notes
   + The default desktop ID generator was replaced by a more secured one.

--- a/zul/src/org/zkoss/zul/Menubar.java
+++ b/zul/src/org/zkoss/zul/Menubar.java
@@ -112,6 +112,7 @@ public class Menubar extends XulElement {
 
 	/** Sets whether to automatically drop down menus if user moves mouse
 	 * over it.
+	 * Only effect on the topmost menu.
 	 */
 	public void setAutodrop(boolean autodrop) {
 		if (_autodrop != autodrop) {


### PR DESCRIPTION
ZK-4811: menubar autodrop="false" has no effect on nested submenus