### PR TITLE
ZK-4793: IndexOutOfBoundsException Tree.renderItemByPath

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -39,6 +39,7 @@ ZK 9.6.0
   ZK-4833: CKEditor fails to initialized if added to a closed detail component
   ZK-4845: notified @load binding not updating inside shadow element
   ZK-4809: NPE with comet server push (servlet 3) reconnect on Tomcat
+  ZK-4793: IndexOutOfBoundsException Tree.renderItemByPath
 
 * Upgrade Notes
   + The default desktop ID generator was replaced by a more secured one.

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -2951,6 +2951,7 @@ B90-ZK-4431.zul=A,E,Multislider
 ##zats##B96-ZK-4833.zul=A,E,Grid,Detail,onRestore,CKEditor,iframe
 ##zats##B96-ZK-4845.zul=A,E,shadow,if,binding
 ##manually##B96-ZK-4809.zul=A,M,Comet,ServerPush,activate,retry,Async,complete,Request,Tomcat
+##zats##B96-ZK-4793.zul=A,E,Tree,renderItemByPath
 
 ##
 # Features - 3.0.x version

--- a/zktest/test/java/org/zkoss/zktest/zats/test2/B96_ZK_4793Test.java
+++ b/zktest/test/java/org/zkoss/zktest/zats/test2/B96_ZK_4793Test.java
@@ -1,0 +1,51 @@
+package org.zkoss.zktest.zats.test2;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.zkoss.zul.Tree;
+import org.zkoss.zul.Treechildren;
+import org.zkoss.zul.Treeitem;
+
+public class B96_ZK_4793Test {
+	@Test
+	public void test() {
+		Treechildren rootChildren = new Treechildren();
+		Treeitem item_1 = new Treeitem("item 1");
+		Treeitem item_2 = new Treeitem("item 2");
+		Treeitem item_3 = new Treeitem("item 3");
+		Treechildren item_1_children = new Treechildren();
+		Treeitem item_11 = new Treeitem("item 1.1");
+		Treechildren item_11_children = new Treechildren();
+		Treeitem item_111 = new Treeitem("item 1.1.1");
+
+		Tree tree = new Tree();
+		tree.appendChild(rootChildren);
+		rootChildren.appendChild(item_1);
+		rootChildren.appendChild(item_2);
+		rootChildren.appendChild(item_3);
+		item_1.appendChild(item_1_children);
+		item_1_children.appendChild(item_11);
+		item_11.appendChild(item_11_children);
+		item_11_children.appendChild(item_111);
+
+		Assert.assertEquals(item_1, tree.renderItemByPath(new int[] {0}));
+		Assert.assertEquals(item_2, tree.renderItemByPath(new int[] {1}));
+		Assert.assertEquals(item_3, tree.renderItemByPath(new int[] {2}));
+		Assert.assertEquals(item_11, tree.renderItemByPath(new int[] {0, 0}));
+		Assert.assertEquals(item_111, tree.renderItemByPath(new int[] {0, 0, 0}));
+
+		Assert.assertNull("null for incorrect path", tree.renderItemByPath(new int[] {-1}));
+		Assert.assertNull("null for incorrect path", tree.renderItemByPath(new int[] {0, -1}));
+		Assert.assertNull("null for incorrect path", tree.renderItemByPath(new int[] {0, 0, -1}));
+
+		Assert.assertNull("null for incorrect path", tree.renderItemByPath(new int[] {4}));
+		Assert.assertNull("null for incorrect path", tree.renderItemByPath(new int[] {0, 2}));
+		Assert.assertNull("null for incorrect path", tree.renderItemByPath(new int[] {0, 0, 2}));
+		Assert.assertNull("null for incorrect path", tree.renderItemByPath(new int[] {0, 0, 100}));
+
+		//these 3 paths fail where the last index is just 1 greater than allowed
+		Assert.assertNull("null for incorrect path", tree.renderItemByPath(new int[] {3}));
+		Assert.assertNull("null for incorrect path", tree.renderItemByPath(new int[] {0, 0, 1}));
+		Assert.assertNull("null for incorrect path", tree.renderItemByPath(new int[] {0, 2}));
+	}
+}

--- a/zul/src/org/zkoss/zul/Tree.java
+++ b/zul/src/org/zkoss/zul/Tree.java
@@ -2563,7 +2563,7 @@ public class Tree extends MeshElement {
 		 * Go through each stop in path and render corresponding treeitem
 		 */
 		for (int i = 0; i < path.length; i++) {
-			if (path[i] < 0 || path[i] > children.size())
+			if (path[i] < 0 || path[i] >= children.size())
 				return null;
 			ti = (Treeitem) children.get(path[i]);
 


### PR DESCRIPTION
ZK-4793: IndexOutOfBoundsException Tree.renderItemByPath