### PR TITLE
refine ZK-4783 zul

### DIFF
--- a/zktest/src/archive/test2/F96-ZK-4783.zul
+++ b/zktest/src/archive/test2/F96-ZK-4783.zul
@@ -16,8 +16,10 @@ Copyright (C) 2021 Potix Corporation. All Rights Reserved.
 	<label multiline="true">
 		1. Test with all themes.
 		2. While word-break fail(alert 1 and messagebox 1), should provide scrollbar.
-		3. messagebox 2 width shoud be 600px.
+		3. While word-break not fail(alert 2 and messagebox 2), should not provide scrollbar.
+		4. messagebox 2 width shoud be 600px.
 	</label>
+	<div>word-break fail</div>
 	<button id="btn1" label="alert 1" onClick='throw new Exception("cannot find any method that is annotated for
 	 the command showHello with @Command in j21eol4p$v0.HelloViewModel@fff330ce at
 	[file:/tmp/resource463596934025823ffdsfafdasf0562tmp/21eol4p/0/index.zul, line:4]");'/>
@@ -26,11 +28,13 @@ Copyright (C) 2021 Potix Corporation. All Rights Reserved.
 			Messagebox.show("[file:/tmp/resource463596934025823ffdsfafdasf0562tmp/21eol4p/0/index.zul, line:4]", "Warning", Messagebox.OK, Messagebox.EXCLAMATION);
 		]]></attribute>
 	</button>
+	<div>word-break not fail</div>
+	<button id="btn2" label="alert 2" onClick='throw new Exception("this is a text which should line break without causing any scrollbars.");'/>
 	<button label="messagebox2">
 		<attribute name="onClick"><![CDATA[
 			Map params = new HashMap();
 			params.put("width", "600px");
-			Messagebox.show("Information is pressed.",null, null, null, Messagebox.INFORMATION, null,null, params);
+			Messagebox.show("this is a text which should line break without causing any scrollbars.",null, null, null, Messagebox.INFORMATION, null,null, params);
 		]]></attribute>
 	</button>
 </zk>

--- a/zktest/test/java/org/zkoss/zktest/zats/test2/F96_ZK_4783Test.java
+++ b/zktest/test/java/org/zkoss/zktest/zats/test2/F96_ZK_4783Test.java
@@ -22,13 +22,6 @@ public class F96_ZK_4783Test extends WebDriverTestCase {
 		connect();
 		click(jq("@a:contains(Default)"));
 		testMessagebox(480);
-
-		JQuery msgBox = jq(".z-messagebox-window");
-		click(msgBox.find("@button"));
-		waitResponse();
-		click(jq("@button:contains(messagebox2)"));
-		waitResponse();
-		Assert.assertEquals(600, msgBox.outerWidth());
 	}
 	@Test
 	public void testBreeze() {
@@ -71,5 +64,18 @@ public class F96_ZK_4783Test extends WebDriverTestCase {
 		waitResponse();
 		Assert.assertTrue(Boolean.valueOf(zk(msgBoxViewport).eval("hasHScroll()")));
 		Assert.assertEquals(width, Integer.valueOf(msgBox.outerWidth()));
+		click(msgBox.find("@button"));
+
+		click(jq("@button:contains(alert 2)"));
+		waitResponse();
+		Assert.assertFalse(Boolean.valueOf(zk(msgBoxViewport).eval("hasHScroll()")));
+		Assert.assertEquals(width, Integer.valueOf(msgBox.outerWidth()));
+		click(msgBox.find("@button"));
+
+		click(jq("@button:contains(messagebox2)"));
+		waitResponse();
+		Assert.assertFalse(Boolean.valueOf(zk(msgBoxViewport).eval("hasHScroll()")));
+		Assert.assertEquals(600, msgBox.outerWidth());
+		click(msgBox.find("@button"));
 	}
 }

--- a/zul/src/archive/web/js/zul/wnd/messagebox.js
+++ b/zul/src/archive/web/js/zul/wnd/messagebox.js
@@ -1,9 +1,13 @@
 zul.wnd.Messagebox = {
 	onBind: function (label, minWidth) {
 		var win = label.$o(),
-			outer = win.$n();
+			outer = win.$n(),
+			msgbox = label.$n().parentElement,
+			outerOrigWd = outer.offsetWidth;
+
 		if (minWidth) {
 			outer.style.width = jq.px0(Math.min(zk.parseInt(minWidth), jq.innerWidth() - 20));
+			msgbox.style.width = jq.px0(zk.parseInt(minWidth) - (outerOrigWd - msgbox.offsetWidth));
 		}
 		zk(outer).center();
 		var top = zk.parseInt(outer.style.top), y = jq.innerY();


### PR DESCRIPTION
refine ZK-4783: Modify error message box CSS design (provide scrollbar while word-break fail)