### PR TITLE
ZK-4831: parseStyle splits css string incorrectly

### DIFF
--- a/zk/src/archive/web/js/zk/dom.ts
+++ b/zk/src/archive/web/js/zk/dom.ts
@@ -2280,7 +2280,7 @@ jq.filterTextStyle({width:"100px", fontSize: "10pt"});
 		if (style) {
 			var pairs = style.split(';');
 			for (var j = 0, len = pairs.length; j < len;) {
-				var v = pairs[j++].split(':'),
+				var v = pairs[j++].split(/:(.+)/),
 					nm = v.length > 0 ? v[0].trim() : '';
 				if (nm)
 					map[nm] = v.length > 1 ? v[1].trim() : '';

--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -51,6 +51,7 @@ ZK 9.6.0
   ZK-4840: navbar navitem icon/text alignment
   ZK-4782: vflex on goldenpanel doesn't work as expected
   ZK-4851: Datebox fails with default DateFormat from Java 11.0.2+
+  ZK-4831: parseStyle splits css string incorrectly
 
 * Upgrade Notes
   + The default desktop ID generator was replaced by a more secured one.

--- a/zktest/src/archive/test2/B96-ZK-4831.zul
+++ b/zktest/src/archive/test2/B96-ZK-4831.zul
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+B96-ZK-4831.zul
+
+	Purpose:
+
+	Description:
+
+	History:
+		Thu Apr 08 12:29:15 CST 2021, Created by katherinelin
+
+Copyright (C) 2021 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+	<label multiline="true">
+		1. click button to set background-image.
+		2. the div background image should fill with an icon_browser picture.
+	</label>
+	<button label="set background-image" onClick="setStyle()"/>
+	<div id="div" width="200px" height="200px" style="border: 1px solid black">div</div>
+	<zscript>
+		void setStyle() {
+		div.setStyle("background-image:url('http://localhost:8080/zktest/test2/img/icon_browser.png')");
+		}
+	</zscript>
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -2961,6 +2961,7 @@ B90-ZK-4431.zul=A,E,Multislider
 ##zats##B96-ZK-4840.zul=A,E,Nav,Navitem,Style,Themes
 ##zats##B96-ZK-4782.zul=A,E,GoldenLayout,vflex
 ##zats##B96-ZK-4851.zul=A,E,GoldenLayout,vflex
+##zats##B96-ZK-4831.zul=A,E,Dom,parseStyle
 
 ##
 # Features - 3.0.x version

--- a/zktest/test/java/org/zkoss/zktest/zats/test2/B96_ZK_4831Test.java
+++ b/zktest/test/java/org/zkoss/zktest/zats/test2/B96_ZK_4831Test.java
@@ -1,0 +1,28 @@
+/* B96_ZK_4831Test.java
+
+	Purpose:
+		
+	Description:
+		
+	History:
+		Fri Apr 09 11:53:56 CST 2021, Created by katherinelin
+
+Copyright (C) 2021 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.zkoss.zktest.zats.WebDriverTestCase;
+import org.zkoss.zktest.zats.ztl.JQuery;
+
+public class B96_ZK_4831Test extends WebDriverTestCase {
+	@Test
+	public void test() {
+		connect();
+		click(jq("@button"));
+		waitResponse();
+		String background = jq("$div").css("background-image");
+		Assert.assertEquals("url(\"http://localhost:8080/zktest/test2/img/icon_browser.png\")", background);
+	}
+}


### PR DESCRIPTION
ZK-4831: parseStyle splits css string incorrectly