### PR TITLE
ZK-4728: Treeitem with visible="false" is not rendered, cause null on…

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -112,6 +112,7 @@ ZK 9.6.0
   ZK-4837: Searchbox doesn't render items for a ListModelList change in an onOpen listener
   ZK-4921: listbox with a SimpleGroupsModel doesn't fire an expected onSelect event
   ZK-4916: tbeditor setValue only sets source, doesn't affect display without rerender
+  ZK-4728: Treeitem with visible="false" is not rendered, cause null on treeItem.$n() when toggling parent open status
 
 * Upgrade Notes
   + The default desktop ID generator was replaced by a more secured one.

--- a/zktest/src/archive/test2/B96-ZK-4728.zul
+++ b/zktest/src/archive/test2/B96-ZK-4728.zul
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+B96-ZK-4728.zul
+
+	Purpose:
+		
+	Description:
+		
+	History:
+		Thu Jun 10 15:49:56 CST 2021, Created by rudyhuang
+
+Copyright (C) 2021 Potix Corporation. All Rights Reserved.
+
+-->
+<zk>
+    <script><![CDATA[
+    window.onerror = function (message) {
+        zk.log(message);
+    };
+    ]]>
+    </script>
+    <label multiline="true">
+    1. Try to collapse and expand treeitem 'Item 2'.
+    2. No error in the browser dev console and 'Item 2' was collapses/expanded normally.
+    </label>
+    <div>
+        <tree id="tree" rows="5" mold="paging">
+            <treecols sizable="true">
+                <treecol label="Name" />
+                <treecol label="Description" />
+            </treecols>
+            <treechildren>
+                <treeitem>
+                    <treerow>
+                        <treecell label="Item 1" />
+                        <treecell label="Item 1 description" />
+                    </treerow>
+                </treeitem>
+                <treeitem id="parent">
+                    <treerow>
+                        <treecell label="Item 2" />
+                        <treecell label="Item 2 description" />
+                    </treerow>
+                    <treechildren>
+                        <treeitem id="child" visible="false">
+                            <treerow>
+                                <treecell label="Item 2.1" />
+                            </treerow>
+                            <treechildren>
+                                <treeitem visible="false">
+                                    <treerow>
+                                        <treecell label="Item 2.1.1" />
+                                    </treerow>
+                                </treeitem>
+                            </treechildren>
+                        </treeitem>
+                        <treeitem id="child2">
+                            <treerow>
+                                <treecell label="Item 2.2" />
+                                <treecell label="Item 2.2 is something" />
+                            </treerow>
+                        </treeitem>
+                    </treechildren>
+                </treeitem>
+                <treeitem label="Item 3" />
+            </treechildren>
+            <treefoot>
+                <treefooter label="Count" />
+                <treefooter label="Summary" />
+            </treefoot>
+        </tree>
+    </div>
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -3007,6 +3007,7 @@ B90-ZK-4431.zul=A,E,Multislider
 ##manually##B96-ZK-4930.zul=A,E,WebSocket,Response,recycle,Tomcat10
 ##zats##B96-ZK-4921.zul=A,E,Listbox,select,event
 ##zats##B96-ZK-4916.zul=A,E,Tbeditor
+##zats##B96-ZK-4728.zul=A,E,Tree,Treeitem,paging,visible,open
 
 ##
 # Features - 3.0.x version

--- a/zktest/test/java/org/zkoss/zktest/zats/test2/B96_ZK_4728Test.java
+++ b/zktest/test/java/org/zkoss/zktest/zats/test2/B96_ZK_4728Test.java
@@ -1,0 +1,41 @@
+/* B96_ZK_4728Test.java
+
+	Purpose:
+		
+	Description:
+		
+	History:
+		Thu Jun 10 16:14:12 CST 2021, Created by rudyhuang
+
+Copyright (C) 2021 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.zkoss.zktest.zats.WebDriverTestCase;
+import org.zkoss.zktest.zats.ztl.Widget;
+
+/**
+ * @author rudyhuang
+ */
+public class B96_ZK_4728Test extends WebDriverTestCase {
+	@Test
+	public void test() {
+		connect();
+
+		final Widget item2 = widget("$parent");
+		click(item2.$n("open"));
+		waitResponse();
+		assertNoJSError();
+		Assert.assertFalse(jq("$child1").isVisible());
+		Assert.assertFalse(jq("$child2").isVisible());
+
+		click(item2.$n("open"));
+		waitResponse();
+		assertNoJSError();
+		Assert.assertFalse(jq("$child1").isVisible());
+		Assert.assertTrue(jq("$child2").isVisible());
+	}
+}

--- a/zul/src/archive/web/js/zul/sel/Treeitem.js
+++ b/zul/src/archive/web/js/zul/sel/Treeitem.js
@@ -170,7 +170,9 @@ zul.sel.Treeitem = zk.$extends(zul.sel.ItemWidget, {
 		var tc = this.treechildren;
 		if (tc)
 			for (var w = tc.firstChild, vi = tc._isRealVisible(); w; w = w.nextSibling) {
-				w.$n().style.display = vi && w.isVisible() && open ? '' : 'none';
+				var n = w.$n();
+				if (n)
+					n.style.display = vi && w.isVisible() && open ? '' : 'none';
 				if (w.isOpen())
 					w._showKids(open);
 			}


### PR DESCRIPTION
… treeItem.$n() when toggling parent open status