### PR TITLE
refine test cases

### DIFF
--- a/zktest/src/archive/test2/B70-ZK-2567.jsp
+++ b/zktest/src/archive/test2/B70-ZK-2567.jsp
@@ -1,10 +1,4 @@
-<html>
-<head>
-<title>Insert title here</title>
-</head>
-<body>
 <div>
-JSPPPPPPPPP
+<%= "JSPPPPPPPPP" %>
+<%= java.util.Calendar.getInstance().getTime() %>
 </div>
-</body>
-</html>

--- a/zktest/test/java/org/zkoss/zktest/zats/test2/B80_ZK_2964Test.java
+++ b/zktest/test/java/org/zkoss/zktest/zats/test2/B80_ZK_2964Test.java
@@ -13,11 +13,13 @@ package org.zkoss.zktest.zats.test2;
 
 import static org.junit.Assert.assertTrue;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
 import java.util.Locale;
 
 import org.junit.Test;
+
 import org.zkoss.zktest.zats.WebDriverTestCase;
 import org.zkoss.zktest.zats.ztl.JQuery;
 import org.zkoss.zktest.zats.ztl.Widget;
@@ -26,24 +28,26 @@ import org.zkoss.zktest.zats.ztl.Widget;
  * @author jumperchen
  */
 public class B80_ZK_2964Test extends WebDriverTestCase {
-	private static SimpleDateFormat sdf0 = new SimpleDateFormat("h:mm:ss a",
-			Locale.ENGLISH);
-	private static SimpleDateFormat sdf1 = new SimpleDateFormat("h:mm a",
-			Locale.ENGLISH);
-	@Test public void testZK2964() throws ParseException {
+	private static final DateTimeFormatter formatter = new DateTimeFormatterBuilder()
+			.appendPattern("[h:mm:ss a]")
+			.appendPattern("[a h:mm:ss]")
+			.appendPattern("[h:mm a]")
+			.appendPattern("[a h:mm]")
+			.toFormatter(Locale.ENGLISH);
+
+	@Test public void testZK2964() throws DateTimeParseException {
 		connect();
 		JQuery dateboxes = jq("@datebox");
-		testTimeformat(widget(dateboxes.get(0)), sdf0);
-		testTimeformat(widget(dateboxes.get(1)), sdf0);
-		testTimeformat(widget(dateboxes.get(2)), sdf0);
-		testTimeformat(widget(dateboxes.get(3)), sdf1);
-
+		testTimeformat(widget(dateboxes.get(0)));
+		testTimeformat(widget(dateboxes.get(1)));
+		testTimeformat(widget(dateboxes.get(2)));
+		testTimeformat(widget(dateboxes.get(3)));
 	}
 
-	private void testTimeformat(Widget widget, SimpleDateFormat sdf)
-			throws ParseException {
+	private void testTimeformat(Widget widget)
+			throws DateTimeParseException {
 		click(widget.$n("btn"));
 		assertTrue(jq(widget.$n("pp")).find(".z-timebox-input").exists());
-		sdf.parse(jq(widget.$n("pp")).find(".z-timebox-input").val());
+		formatter.parse(jq(widget.$n("pp")).find(".z-timebox-input").val());
 	}
 }

--- a/zktest/test/java/org/zkoss/zktest/zats/test2/B80_ZK_3046Test.java
+++ b/zktest/test/java/org/zkoss/zktest/zats/test2/B80_ZK_3046Test.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
+
 import org.zkoss.zktest.zats.WebDriverTestCase;
 import org.zkoss.zktest.zats.ztl.JQuery;
 
@@ -25,13 +26,12 @@ public class B80_ZK_3046Test extends WebDriverTestCase {
 	@Test public void testZK3046() {
 		connect();
 		JQuery groups = jq("@groupbox");
-		checkResult(groups, 7, 5);
+		checkResult(groups, 7);
 	}
-	private void checkResult(JQuery groups, int groupsLen, int buttonLen) {
+	private void checkResult(JQuery groups, int groupsLen) {
 		assertEquals(groupsLen, groups.length());
 		for (JQuery group : groups) {
 			JQuery buttons = group.find("button");
-			assertEquals(buttonLen, buttons.length());
 			for (JQuery button : buttons) {
 				String text = button.text();
 				assertTrue(text.startsWith("zh"));
@@ -45,26 +45,26 @@ public class B80_ZK_3046Test extends WebDriverTestCase {
 	@Test public void testZK3046_1() {
 		connect(getTestURL("B80-ZK-3046-1.zul"));
 		JQuery groups = jq("@groupbox");
-		checkResult(groups, 1, 5);
+		checkResult(groups, 1);
 	}
 	@Test public void testZK3046_2() {
 		connect(getTestURL("B80-ZK-3046-2.zul"));
 		JQuery groups = jq("@groupbox");
-		checkResult(groups, 1, 5);
+		checkResult(groups, 1);
 	}
 	@Test public void testZK3046_3() {
 		connect(getTestURL("B80-ZK-3046-3.zul"));
 		JQuery groups = jq("@groupbox");
-		checkResult(groups, 1, 5);
+		checkResult(groups, 1);
 	}
 	@Test public void testZK3046_4() {
 		connect(getTestURL("B80-ZK-3046-4.zul"));
 		JQuery groups = jq("@groupbox");
-		checkResult(groups, 1, 5);
+		checkResult(groups, 1);
 	}
 	@Test public void testZK3046_5() {
 		connect(getTestURL("B80-ZK-3046-5.zul"));
 		JQuery groups = jq("@groupbox");
-		checkResult(groups, 1, 10);
+		checkResult(groups, 1);
 	}
 }

--- a/zktest/test/java/org/zkoss/zktest/zats/test2/B85_ZK_3848Test.java
+++ b/zktest/test/java/org/zkoss/zktest/zats/test2/B85_ZK_3848Test.java
@@ -33,6 +33,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.slf4j.Logger;
@@ -42,6 +43,7 @@ import org.zkoss.util.resource.ClassLocator;
 
 @RunWith (PowerMockRunner.class)
 @PrepareForTest ({LoggerFactory.class})
+@PowerMockIgnore("jdk.internal.reflect.*")
 public class B85_ZK_3848Test {
 	private static Logger logger;
 	private static ClassLocator clToTest;

--- a/zktest/test/java/org/zkoss/zktest/zats/test2/F96_ZK_4745Test.java
+++ b/zktest/test/java/org/zkoss/zktest/zats/test2/F96_ZK_4745Test.java
@@ -11,8 +11,11 @@ Copyright (C) 2021 Potix Corporation. All Rights Reserved.
 */
 package org.zkoss.zktest.zats.test2;
 
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
+
 import org.zkoss.zktest.zats.WebDriverTestCase;
 import org.zkoss.zktest.zats.ztl.Element;
 
@@ -108,7 +111,7 @@ public class F96_ZK_4745Test extends WebDriverTestCase {
 
 		click(jq("@button:eq(5)"));
 		waitResponse();
-		Assert.assertEquals("R.O.C. 104-01-01", db5real.get("value"));
+		MatcherAssert.assertThat(db5real.get("value"), Matchers.matchesRegex("(R\\.O\\.C\\.|Minguo) 104-01-01"));
 	}
 
 	private void checkDateboxCalendar(Element btn, String expectedTitle, String expectedDay) {

--- a/zktest/test/java/org/zkoss/zktest/zats/test2/F96_ZK_4745_2Test.java
+++ b/zktest/test/java/org/zkoss/zktest/zats/test2/F96_ZK_4745_2Test.java
@@ -11,8 +11,11 @@ Copyright (C) 2021 Potix Corporation. All Rights Reserved.
 */
 package org.zkoss.zktest.zats.test2;
 
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
+
 import org.zkoss.zktest.zats.WebDriverTestCase;
 import org.zkoss.zktest.zats.ztl.Element;
 
@@ -30,15 +33,15 @@ public class F96_ZK_4745_2Test  extends WebDriverTestCase {
 
 		type(db1real, "大正14/07/31");
 		Assert.assertFalse(hasError());
-		checkDateboxCalendar(db1btn, "7 大正14", "31");
+		checkDateboxCalendar(db1btn, "7(月)? 大正14", "31");
 
 		type(db2real, "大正 14/07/31");
 		Assert.assertFalse(hasError());
-		checkDateboxCalendar(db2btn, "7 大正14", "31");
+		checkDateboxCalendar(db2btn, "7(月)? 大正14", "31");
 
 		type(db3real, "2022/01/01");
 		Assert.assertFalse(hasError());
-		checkDateboxCalendar(db3btn, "1 令和4", "1");
+		checkDateboxCalendar(db3btn, "1(月)? 令和4", "1");
 	}
 
 	@Test
@@ -69,7 +72,7 @@ public class F96_ZK_4745_2Test  extends WebDriverTestCase {
 
 		type(db4real, "西暦 2021-02-03");
 		Assert.assertFalse(hasError());
-		checkDateboxCalendar(db4btn, "2 2021", "3");
+		checkDateboxCalendar(db4btn, "2(月)? 2021", "3");
 	}
 
 	@Test
@@ -116,7 +119,7 @@ public class F96_ZK_4745_2Test  extends WebDriverTestCase {
 		waitResponse();
 		String calendarTitle = jq(".z-calendar-title").last().text();
 		String currentDay = jq(".z-calendar-selected").last().text();
-		Assert.assertEquals(expectedTitle, calendarTitle);
+		MatcherAssert.assertThat(calendarTitle, Matchers.matchesRegex(expectedTitle));
 		Assert.assertEquals(expectedDay, currentDay);
 		click(jq("@label"));
 		waitResponse();


### PR DESCRIPTION
2567: conflict with ZK-2642
2964: Update Time Parser
3046: Remove the count check (it depends on Java versions)
3848: PowerMock Java 11 workaround
4745: Format differs in Java versions