### PR TITLE
refine ZK-4748: bandpopup close while open the treeitem in No-A11y

### DIFF
--- a/zul/src/archive/web/js/zul/inp/Bandpopup.js
+++ b/zul/src/archive/web/js/zul/inp/Bandpopup.js
@@ -37,8 +37,9 @@ zul.inp.Bandpopup = zk.$extends(zul.Widget, {
 	},
 	_focusout: function (e) {
 		var bandbox = this.parent,
-			self = this;
-		self._shallClosePopup = true;
+			self = this,
+			pp = bandbox && bandbox.$n('pp');
+		self._shallClosePopup = pp != null && e.relatedTarget != pp;
 		setTimeout(function () {
 			if (bandbox && bandbox.isOpen() && self._shallClosePopup) {
 				bandbox.close();


### PR DESCRIPTION
refine ZK-4748: bandpopup close while open the treeitem in No-A11y