### PR TITLE
Add ckeditor attributes to zul.xsd

### DIFF
--- a/zul/src/archive/metainfo/xml/zul.xsd
+++ b/zul/src/archive/metainfo/xml/zul.xsd
@@ -3876,6 +3876,8 @@
 		<xs:attribute name="hflex" type="xs:string" use="optional" />
 		<xs:attribute name="vflex" type="xs:string" use="optional" />
 		<xs:attribute name="customConfigurationsPath" type="xs:string" use="optional" />
+		<xs:attribute name="autoHeight" type="booleanType" use="optional" />
+		<xs:attribute name="resizable" type="booleanType" use="optional" />
 	</xs:complexType>
 	<!-- fckeditor -->
 	<xs:element name="fckeditor" type="fckeditorType" />


### PR DESCRIPTION
ZKCK-67: editor component height may not match client height