### PR TITLE
ZK-4995: signature component on tablet/mobile cutting off image

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -2,6 +2,7 @@ ZK 9.6.1
 * Features
 
 * Bugs
+  ZK-4995: signature component on tablet/mobile cutting off image
 
 * Upgrade Notes
 

--- a/zktest/src/archive/test2/B96-ZK-4995.zul
+++ b/zktest/src/archive/test2/B96-ZK-4995.zul
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+B96-ZK-4995.zul
+
+	Purpose:
+
+	Description:
+
+	History:
+		Mon Aug 16 12:17:34 CST 2021, Created by katherine
+
+Copyright (C) 2021 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+	<label multiline="true">
+		1. open this page with tablet/mobile devices.
+		2. write some text and click save.
+		3. the image is saved as same size.
+	</label>
+	<signature height="200px" width="100%" onSave="output.setContent(event.getMedia())"/>
+	<image id="output" width="100%"/>
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -3046,6 +3046,7 @@ B90-ZK-4431.zul=A,E,Multislider
 ##manually##B96-ZK-4939.zul=A,E,iconSclass
 ##zats##B96-ZK-4979.zul=A,E,Button,onRightClick,disabled,Chrome
 ##zats##B96-ZK-4977.zul=A,E,MatchMedia,Chrome
+##manually##B96-ZK-4995.zul=A,E,signature
 
 ##
 # Features - 3.0.x version


### PR DESCRIPTION
ZK-4995: signature component on tablet/mobile cutting off image