### PR TITLE
ZK-5123: Searchbox open attribute doesn't work while initializing

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -3,6 +3,7 @@ ZK 10.0.0
   ZK-5024: Add a library property to change the default apply composer for MVVM
   ZK-5039: remove deprecated classicblue theme in ZK 10
   ZK-5091: Move Layout.java to extend from XulElement
+  ZK-5123: Searchbox open attribute doesn't work while initializing
 
 * Bugs
   ZK-5089: AfterSizeEvent doesn't return a correct size of a Window component

--- a/zktest/src/main/webapp/test2/B100-ZK-5123.zul
+++ b/zktest/src/main/webapp/test2/B100-ZK-5123.zul
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+B100-ZK-5123.zul
+
+	Purpose:
+
+	Description:
+
+	History:
+		Wed Mar 09 11:45:08 CST 2022, Created by katherine
+
+Copyright (C) 2022 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+	<label>You should see searchbox popup open.</label>
+	<separator/>
+	<searchbox open="true" />
+</zk>

--- a/zktest/src/main/webapp/test2/config.properties
+++ b/zktest/src/main/webapp/test2/config.properties
@@ -3069,6 +3069,7 @@ B90-ZK-4431.zul=A,E,Multislider
 
 ## B100
 ##zats##B100-ZK-5089.zul=A,E,Window,AfterSizeEvent
+##zats##B100-ZK-5123.zul=A,E,Searchbox,open
 
 ##
 # Features - 3.0.x version

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B100_ZK_5123Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B100_ZK_5123Test.java
@@ -1,0 +1,27 @@
+/* B100_ZK_5123Test.java
+
+	Purpose:
+
+	Description:
+
+	History:
+		Wed Mar 09 11:45:40 CST 2022, Created by katherine
+
+Copyright (C) 2022 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import org.zkoss.zktest.zats.WebDriverTestCase;
+
+public class B100_ZK_5123Test extends WebDriverTestCase {
+	@Test
+	public void test() {
+		connect();
+		waitResponse();
+		assertTrue(jq(".z-searchbox-popup").isVisible());
+	}
+}


### PR DESCRIPTION
ZK-5123: Searchbox open attribute doesn't work while initializing