### PR TITLE
ZK-4986: version information not salted for static resources

### DIFF
--- a/zk/src/org/zkoss/zk/ui/http/Utils.java
+++ b/zk/src/org/zkoss/zk/ui/http/Utils.java
@@ -216,4 +216,14 @@ public class Utils {
 		}
 		return updateURI;
 	}
+
+	/**
+	 * obfuscate object with salt string
+	 * @param obj target object
+	 * @param salt string
+	 * @return hex string
+	 */
+	/*package*/ static String obfuscateHashWithSalt(Object obj, String salt) {
+		return Integer.toHexString(37 * obj.hashCode() + salt.hashCode());
+	}
 }

--- a/zk/src/org/zkoss/zk/ui/http/WebManager.java
+++ b/zk/src/org/zkoss/zk/ui/http/WebManager.java
@@ -295,7 +295,12 @@ public class WebManager {
 
 	/** Returns the prefix of URL to represent this build. */
 	private String getCWRURLPrefix() {
-		int code = _wapp.getVersion().hashCode() ^ _wapp.getBuild().hashCode() ^ WebApps.getEdition().hashCode();
+		final String verInfoEnabled = Library.getProperty("org.zkoss.zk.ui.versionInfo.enabled", "true");
+		String build = _wapp.getBuild();
+		if (!"true".equals(verInfoEnabled)) {
+			return org.zkoss.zk.ui.http.Utils.obfuscateHashWithSalt(build, verInfoEnabled);
+		}
+		int code = _wapp.getVersion().hashCode() ^ build.hashCode() ^ WebApps.getEdition().hashCode();
 
 		for (Iterator<LanguageDefinition> it = LanguageDefinition.getAll().iterator(); it.hasNext();) {
 			final LanguageDefinition langdef = it.next();

--- a/zk/src/org/zkoss/zk/ui/http/WpdExtendlet.java
+++ b/zk/src/org/zkoss/zk/ui/http/WpdExtendlet.java
@@ -621,7 +621,8 @@ public class WpdExtendlet extends AbstractExtendlet<Object> {
 		else
 			sb.append("\nzkver('','");
 
-		sb.append(obfuscateVer(exposeVer, wapp.getBuild(), verInfoEnabled));
+		String build = wapp.getBuild();
+		sb.append(exposeVer ? build : Utils.obfuscateHashWithSalt(build, verInfoEnabled));
 
 		final ServletContext ctx = getServletContext();
 		String s = Encodes.encodeURL(ctx, reqctx.request, reqctx.response, "/");
@@ -637,8 +638,9 @@ public class WpdExtendlet extends AbstractExtendlet<Object> {
 			final LanguageDefinition langdef = (LanguageDefinition) it.next();
 			for (Iterator e = langdef.getJavaScriptModules().entrySet().iterator(); e.hasNext();) {
 				final Map.Entry me = (Map.Entry) e.next();
+				Object value = me.getValue();
 				sb.append('\'').append(me.getKey()).append("':'")
-						.append(obfuscateVer(exposeVer, me.getValue(), verInfoEnabled)).append("',");
+						.append(exposeVer ? value : Utils.obfuscateHashWithSalt(value, verInfoEnabled)).append("',");
 			}
 			removeLast(sb, ',');
 		}
@@ -689,10 +691,6 @@ public class WpdExtendlet extends AbstractExtendlet<Object> {
 				.append(Encodes.encodeURL(ctx, reqctx.request, reqctx.response, wapp.getResourceURI(false)))
 				.append("'").append("});");
 		appendPostJsScript((ByteArrayOutputStream) out, sourceMapManager, sb.toString());
-	}
-
-	private Object obfuscateVer(boolean exposeVersion, Object ver, String salt) {
-		return exposeVersion ? ver : Integer.toHexString(37 * ver.hashCode() + salt.hashCode());
 	}
 
 	private void outErrReloads(RequestContext reqctx, Configuration config, StringBuffer sb, Object[][] infs) {

--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -2,6 +2,8 @@ ZK 9.6.2
 * Features
 
 * Bugs
+  ZK-4986: version information not salted for static resources
+  ZK-5071: org.zkoss.zk.ui.versionInfo.enabled cannot bust browser cache
 
 * Upgrade Notes
 

--- a/zktest/src/archive/test2/B96-ZK-4986.zul
+++ b/zktest/src/archive/test2/B96-ZK-4986.zul
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?link rel='stylesheet' href="~./css/common.css"?>
+<!--
+B96-ZK-4986.zul
+
+	Purpose:
+
+	Description:
+
+	History:
+		Thu Apr 21 10:22:32 CST 2022, Created by jameschu
+
+Copyright (C) 2022 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+	<label multiline="true"><![CDATA[
+		1. load this page to see the request path of "common.css" and "*.wpd" (open developer tool, make sure don't "disable cache")
+		2. specify library-property (different value)
+		<library-property>
+			<name>org.zkoss.zk.ui.versionInfo.enabled</name>
+			<value>2021</value>
+    	</library-property>
+    	3. restart server and see the paths above changed
+	]]></label>
+	<datebox />
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -3066,6 +3066,7 @@ B90-ZK-4431.zul=A,E,Multislider
 ##Manually##B96-ZK-4989.zul=A,E,Radio,Radiogroup,TabletUI,Theme,CSS
 ##zats##B96-ZK-4970.zul=A,E,Listbox,Model,ListitemRender
 ##zats##B96-ZK-5058.zul=A,E,NoDom,Groupbox,Caption,onSize
+##manually##B96-ZK-4986.zul=A,E,cache,wpd,resource
 
 ##
 # Features - 3.0.x version


### PR DESCRIPTION
ZK-5071: org.zkoss.zk.ui.versionInfo.enabled cannot bust browser cache