### PR TITLE
ZK-5145: Chosenbox smart update emptyMessage doesn't work

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -6,6 +6,7 @@ ZK 10.0.0
 
 * Bugs
   ZK-5089: AfterSizeEvent doesn't return a correct size of a Window component
+  ZK-5145: Chosenbox smart update emptyMessage doesn't work
 
 * Upgrade Notes
   + Layout.java (Vlayout and Hlayout) are extended from XulElement since ZK 10.0.0

--- a/zktest/src/main/webapp/test2/B100-ZK-5145.zul
+++ b/zktest/src/main/webapp/test2/B100-ZK-5145.zul
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+B100-ZK-5145.zul
+
+	Purpose:
+
+	Description:
+
+	History:
+		Fri Apr 22 09:14:41 CST 2022, Created by katherine
+
+Copyright (C) 2022 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+	<label multiline="true">
+		1. click button to update empty message.
+		2. you should see empty message is 'none'.
+	</label>   <chosenbox id="cb" emptyMessage="empty..."/>
+	<button label="update emptyMessage" onClick='cb.setEmptyMessage("none");'/>
+	<zscript>
+		String[] items = {
+			"item 1", "item 2"
+		};
+		ListModel dictModel = new SimpleListModel(items);
+		cb.setModel(dictModel);
+	</zscript>
+</zk>

--- a/zktest/src/main/webapp/test2/config.properties
+++ b/zktest/src/main/webapp/test2/config.properties
@@ -3069,6 +3069,7 @@ B90-ZK-4431.zul=A,E,Multislider
 
 ## B100
 ##zats##B100-ZK-5089.zul=A,E,Window,AfterSizeEvent
+##zats##B100-ZK-5145.zul=A,E,Chosenbox,emptyMessage
 
 ##
 # Features - 3.0.x version

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B100_ZK_5145Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B100_ZK_5145Test.java
@@ -1,0 +1,30 @@
+/* B100_ZK_5145Test.java
+
+	Purpose:
+		
+	Description:
+		
+	History:
+		Fri Apr 22 09:14:41 CST 2022, Created by katherine
+
+Copyright (C) 2022 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.zkoss.zktest.zats.WebDriverTestCase;
+
+/**
+ * @author katherine
+ */
+public class B100_ZK_5145Test extends WebDriverTestCase {
+	@Test
+	public void test() {
+		connect();
+		click(jq("@button"));
+		waitResponse();
+		Assert.assertEquals("none", jq(".z-chosenbox-input").val());
+	}
+}


### PR DESCRIPTION
ZK-5145: Chosenbox smart update emptyMessage doesn't work