### PR TITLE
ZK-5253: title of borderlayout north/south shouldn't rotate 90 degrees

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -2,6 +2,7 @@ ZK 9.6.3
 * Features
 
 * Bugs
+  ZK-5253: title of borderlayout north/south shouldn't rotate 90 degrees
 
 * Upgrade Notes
 

--- a/zktest/src/archive/test2/B96-ZK-5253.zul
+++ b/zktest/src/archive/test2/B96-ZK-5253.zul
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<zk>
+	<borderlayout >
+		<north title="North" maxsize="300" size="50%" open="false" >
+			north
+		</north>
+	</borderlayout>
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -3078,6 +3078,7 @@ B90-ZK-4431.zul=A,E,Multislider
 ##zats##B96-ZK-5126.zul=A,E,Chosenbox,escape,XML,emptyMessage
 ##zats##B96-ZK-5095.zul=A,E,Websocket,Serialization,Cluster
 ##manually##B96-ZK-5149.zul=A,E,dnd,dropupload,scroll,anchor,position
+##manually##B96-ZK-5253.zul=A,E,Borderlayout,Theme,atlantic,CSS
 
 ##
 # Features - 3.0.x version


### PR DESCRIPTION
This PR should be merge alongside https://github.com/zkoss/atlantic/pull/226