### PR TITLE
ZK-5205: ClientInfoEvent should preserve the precision of devicePixel…

### DIFF
--- a/zk/src/archive/web/js/zk/au.ts
+++ b/zk/src/archive/web/js/zk/au.ts
@@ -1359,7 +1359,7 @@ zAu.cmd0 = /*prototype*/ { //no uuid at all
 	clientInfo: function (dtid) {
 		zAu._cInfoReg = true;
 		var orient = '',
-			dpr = 1;
+			dpr = 1.0;
 		
 		if (zk.mobile) {
 			//change default portrait definition because landscape is the default orientation for this device/browser.
@@ -1376,7 +1376,7 @@ zAu.cmd0 = /*prototype*/ { //no uuid at all
 
 		var clientInfo = [new Date().getTimezoneOffset(),
 				screen.width, screen.height, screen.colorDepth,
-				jq.innerWidth(), jq.innerHeight(), jq.innerX(), jq.innerY(), dpr.toFixed(1), orient,
+				jq.innerWidth(), jq.innerHeight(), jq.innerX(), jq.innerY(), String(dpr), orient,
 				zk.mm.tz.guess()],
 			oldClientInfo = zAu._clientInfo;
 

--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -31,6 +31,7 @@ ZK 9.6.3
   ZK-5148: datebox throws a js error with locale specified
   ZK-5156: locale format doesn't keep the fractional part
   ZK-5180: Bandbox closes its popup when clicking on day of a datebox
+  ZK-5205: ClientInfoEvent should preserve the precision of devicePixelRatio
 
 * Upgrade Notes
 

--- a/zktest/src/archive/test2/B96-ZK-5205.zul
+++ b/zktest/src/archive/test2/B96-ZK-5205.zul
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+B96-ZK-5205.zul
+
+	Purpose:
+		
+	Description:
+		
+	History:
+		2022/10/7, Created by jumperchen
+
+Copyright (C) 2022 Potix Corporation. All Rights Reserved.
+
+-->
+<zk>
+	<script>
+		window.devicePixelRatio = 1.234567;
+	</script>
+	<div onClientInfo="Clients.log(event.getDevicePixelRatio())"/>
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -3104,6 +3104,7 @@ B90-ZK-4431.zul=A,E,Multislider
 ##zats##B96-ZK-5148.zul=A,E,datebox,jserror,constraint
 ##zats##B96-ZK-5156.zul=A,E,Number,format,BigDecimal,locale,precision,fractionDigits
 ##zats##B96-ZK-5180.zul=A,E,Bandpopup,CalendarPop,Datebox,tabindex
+##zats##B96-ZK-5205.zul=A,E,ClientInfo,DevicePixelRatio
 
 ##
 # Features - 3.0.x version

--- a/zktest/test/java/org/zkoss/zktest/zats/test2/B96_ZK_5205Test.java
+++ b/zktest/test/java/org/zkoss/zktest/zats/test2/B96_ZK_5205Test.java
@@ -1,0 +1,32 @@
+/* B96_ZK_5205Test.java
+
+	Purpose:
+		
+	Description:
+		
+	History:
+		11:10 AM 2022/10/7, Created by jumperchen
+
+Copyright (C) 2022 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import org.zkoss.zktest.zats.WebDriverTestCase;
+
+/**
+ * @author jumperchen
+ */
+public class B96_ZK_5205Test extends WebDriverTestCase {
+	@Test
+	public void testClientInfo() {
+		connect();
+		waitResponse();
+		assertEquals(getZKLog(), "1.234567");
+	}
+}


### PR DESCRIPTION
…Ratio