### PR TITLE
ZK-5275: Client MVVM: Support widget properties in command expression

### DIFF
--- a/zephyr-test/src/main/java/org/zkoss/clientbind/test/issue/B01194NestedVMInit.java
+++ b/zephyr-test/src/main/java/org/zkoss/clientbind/test/issue/B01194NestedVMInit.java
@@ -64,9 +64,9 @@ public class B01194NestedVMInit {
 			this.desc = desc;
 		}
 	}
-
-	@Wire
-	private Span headerNameLbOuter;
+//
+//	@Wire
+//	private Span headerNameLbOuter;
 	private VM2 innerVm;
 
 	@Init
@@ -91,10 +91,10 @@ public class B01194NestedVMInit {
 		HashMap<String, String[]> annotAttrs = new HashMap<String, String[]>();
 		annotAttrs.put("value", new String[]{"vm.innerVm.name"});
 		Label headerNameLb = new Label();
-		headerNameLb.setParent(headerNameLbOuter);
+		headerNameLb.setParent(self.getFellow("headerNameLbOuter"));
 		headerNameLb.setId("headerNameLb");
 		headerNameLb.addAnnotation("value", "load", annotAttrs);
-		new AnnotateBinderHelper(binder).initComponentBindings(headerNameLb);
+//		new AnnotateBinderHelper(binder).initComponentBindings(headerNameLb);
 	}
 	
 	public VM2 getInnerVm() {

--- a/zul/src/main/resources/web/js/zul/inp/Combobox.ts
+++ b/zul/src/main/resources/web/js/zul/inp/Combobox.ts
@@ -126,6 +126,14 @@ export class Combobox extends zul.inp.ComboWidget {
 		return this;
 	}
 
+	/**
+	 * Returns the selected item if any.
+	 * @since 10.0.0
+	 */
+	getSelectedItem(): zul.inp.Comboitem | undefined {
+		return this._sel;
+	}
+
 	override onResponse(ctl: zk.ZWatchController, opts: zul.inp.ResponseOptions): void {
 		// Bug ZK-2960: need to wait until the animation is finished before calling super
 		if (this.isOpen() && jq(this.getPopupNode_()).is(':animated')) {


### PR DESCRIPTION
PR should be committed alongside https://github.com/zkoss/zkcml/pull/982