### PR TITLE
ZK-5260: chosenbox options don't escape HTML characters 

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -9,6 +9,7 @@ ZK 9.6.4
   ZK-5251: listbox select mold produces js error in a mobile browser
   ZK-5353: Insertion [] of the shadow [] cannot be orphan in 9.6.3
   ZK-5374: Elements with an ARIA that require children to contain a specific role are missing some or all of those required children
+  ZK-5260: chosenbox options don't escape HTML characters
 
 * Upgrade Notes
 

--- a/zktest/src/archive/test2/B96-ZK-5260.zul
+++ b/zktest/src/archive/test2/B96-ZK-5260.zul
@@ -1,0 +1,7 @@
+<zk>
+	<div>
+		<chosenbox id="chosenbox" name="chosenboxinput" model="@init(vm.model)"
+		           viewModel="@id('vm')@init('org.zkoss.zktest.test2.B96_ZK_5260VM')"
+		           creatable="true" hflex="1" />
+	</div>
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -3116,6 +3116,7 @@ B90-ZK-4431.zul=A,E,Multislider
 ##zats##B96-ZK-5251.zul=A,E,mobile,mold,select
 ##zats##B96-ZK-5353.zul=A,E,shadow,merge
 ##manually##B96-ZK-5374.zul=A,E,a11y,tree,table
+##zats##B96-ZK-5260.zul=A,E,chosenbox,encodeXML
 
 ##
 # Features - 3.0.x version

--- a/zktest/src/org/zkoss/zktest/test2/B96_ZK_5260VM.java
+++ b/zktest/src/org/zkoss/zktest/test2/B96_ZK_5260VM.java
@@ -1,0 +1,21 @@
+package org.zkoss.zktest.test2;
+
+import org.zkoss.zul.ListModelList;
+
+public class B96_ZK_5260VM {
+	final private ListModelList<String> model = new ListModelList<>();
+
+	public B96_ZK_5260VM() {
+		model.add("1@email.io");
+		model.add("2@email.io");
+		model.add("3@email.io");
+		model.add("4@email.io <aerror");
+		model.add("5@email.io");
+		model.add("6@email.io");
+		model.add("7@email.io");
+	}
+
+	public ListModelList<String> getModel() {
+		return model;
+	}
+}

--- a/zktest/test/java/org/zkoss/zktest/zats/test2/B96_ZK_5260Test.java
+++ b/zktest/test/java/org/zkoss/zktest/zats/test2/B96_ZK_5260Test.java
@@ -1,0 +1,28 @@
+package org.zkoss.zktest.zats.test2;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.zkoss.zktest.zats.WebDriverTestCase;
+import org.zkoss.zktest.zats.ztl.JQuery;
+
+public class B96_ZK_5260Test extends WebDriverTestCase {
+	@Test
+	public void test() throws Exception {
+		connect();
+		waitResponse();
+
+		final String textContent = "4@email.io <aerror";
+
+		click(jq("@chosenbox").find("input"));
+		waitResponse();
+		final JQuery chosenOption = jq(".z-chosenbox-option:eq(3)");
+		Assert.assertEquals(textContent, chosenOption.text());
+
+		// `click(chosenOption);` is flaky. Selenium might fail with "Other element would receive the click".
+		// Thus, I click the element by evaluating the following JS snippet.
+		eval("jq('.z-chosenbox-option:eq(3)')[0].click()"); // Equivalent to `click(chosenOption);`.
+		waitResponse();
+		Assert.assertEquals(textContent, jq(".z-chosenbox-item-content").text());
+	}
+}


### PR DESCRIPTION
This PR should be merged alongside [ZKCML#989](https://github.com/zkoss/zkcml/pull/989).