### PR TITLE
ZK-5430: Camera uses incorrect aspect ratio during snapshot if canvas…

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -20,6 +20,7 @@ ZK 9.6.4
   ZK-5133: Radio onPageAttached condition causes onPageAttach to not fix index on parent radiogroup
   ZK-5419: Security upgrade commons fileupload
   ZK-5378: Add safety check to DesktopEventQueue$QueueListener#onEvent
+  ZK-5430: Camera uses incorrect aspect ratio during snapshot if canvas has height / width
 
 * Upgrade Notes
   + Upgrade JRuby dependency from 1.1.2 to 1.7.27 for some security vulnerabilities

--- a/zktest/src/archive/test2/B96-ZK-5430.zul
+++ b/zktest/src/archive/test2/B96-ZK-5430.zul
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+B96-ZK-5430.zul
+
+	Purpose:
+
+	Description:
+
+	History:
+		Tue Apr 18 16:52:31 CST 2023, Created by jameschu
+
+Copyright (C) 2023 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+	<label>click button and see the snapshot with correct ratio</label>
+	<vbox>
+		<camera id="camera" onSnapshotUpload='image.setContent(event.getMedia())' height="300px" width="800px" />
+		<button label="take snapshot" onClick="camera.requestCamera(); camera.snapshot()" />
+		<image id="image" />
+	</vbox>
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -3125,6 +3125,7 @@ B90-ZK-4431.zul=A,E,Multislider
 ##zats##B96-ZK-5423.zul=A,E,locale,pt,datebox,format
 ##zats##B96-ZK-2658.zul=A,E,Listbox,scroll,select,multiple,checkbox
 ##zats##B96-ZK-5133.zul=A,E,radio,onPageAttached,radiogroup
+##manually##B96-ZK-5430.zul=A,camera,dimension,ratio
 
 ##
 # Features - 3.0.x version


### PR DESCRIPTION
… has height / width

This PR should be merge alongside https://github.com/zkoss/zkcml/pull/992.