### PR TITLE
Fix NPE in B70_ZK_2534Test#testSelectRange due to B96-ZK-2658

### DIFF
--- a/zul/src/archive/web/js/zul/sel/SelectWidget.js
+++ b/zul/src/archive/web/js/zul/sel/SelectWidget.js
@@ -1029,8 +1029,8 @@ zul.sel.SelectWidget = zk.$extends(zul.mesh.MeshWidget, {
 		this.fire('onSelect',
 			zk.copy({
 				items: data,
-				firstItemIndex: this.firstItem._index, // ZK-2658
-				lastItemIndex: this.lastItem._index, // ZK-2658
+				// The shape of `rodItemIndexRange` is the same as `range` in listbox-rod#fireOnSelectByRange
+				rodItemIndexRange: { start: this.firstItem?._index, end: this.lastItem?._index }, // ZK-2658
 				reference: ref,
 				clearFirst: !keep,
 				selectAll: checkSelectAll,

--- a/zul/src/org/zkoss/zul/Listbox.java
+++ b/zul/src/org/zkoss/zul/Listbox.java
@@ -3725,8 +3725,20 @@ public class Listbox extends MeshElement {
 								smodel.addToSelection(ele);
 						}
 					}
-					final int firstItemIndex = (int) data.get("firstItemIndex"); // Convert a non-null `Integer` to `int`
-					final int lastItemIndex = (int) data.get("lastItemIndex"); // Same as above
+
+					int firstItemIndex = _items.get(0).getIndex();
+					int lastItemIndex = _items.get(_items.size() - 1).getIndex();
+					final Map<String, Object> rodItemIndexRange = cast((Map) data.get("rodItemIndexRange"));
+					if (rodItemIndexRange != null) {
+						final Integer clientFirstItemIndex = (Integer) rodItemIndexRange.get("start");
+						if (clientFirstItemIndex != null) {
+							firstItemIndex = clientFirstItemIndex;
+						}
+						final Integer clientLastItemIndex = (Integer) rodItemIndexRange.get("end");
+						if (clientLastItemIndex != null) {
+							lastItemIndex = clientLastItemIndex;
+						}
+					}
 					for (final Listitem item : prevSeldItems) {
 						final int index = item.getIndex();
 						if (firstItemIndex <= index && index <= lastItemIndex // ZK-2658


### PR DESCRIPTION
`data.get("firstItemIndex")` or `data.get("lastItemIndex")` could be `null`. In that case, use the available values from `_items`.