### PR TITLE
ZK-5434: Datebox show different time when running with -Duser.timezone="America/Mexico_City"

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -22,6 +22,7 @@ ZK 9.6.4
   ZK-5378: Add safety check to DesktopEventQueue$QueueListener#onEvent
   ZK-5430: Camera uses incorrect aspect ratio during snapshot if canvas has height / width
   ZK-3246: File download doesn't work with Chrome in iOS
+  ZK-5434: Datebox show different time when running with -Duser.timezone="America/Mexico_City"
 
 * Upgrade Notes
   + Upgrade JRuby dependency from 1.1.2 to 1.7.27 for some security vulnerabilities

--- a/zktest/src/archive/test2/B96-ZK-5434.zul
+++ b/zktest/src/archive/test2/B96-ZK-5434.zul
@@ -1,0 +1,89 @@
+<?page title="Timezone test"?>
+<zk xmlns:w="client">
+	<zscript><![CDATA[
+		public class ViewModel {
+			private java.text.SimpleDateFormat sdf = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z");
+			private java.util.Date date = new java.util.Date();
+			private java.util.GregorianCalendar cal = new java.util.GregorianCalendar();
+			
+			public java.util.Date getDate() {
+				return date;
+			}
+			public String getFormatedDate() {
+				return sdf.format(date);
+			}
+			public String getLocale() {
+				return Locale.getDefault().toString();
+			}
+			public String getTimezone() {
+				return TimeZone.getDefault().toString();
+			}
+			public int getDstOffset() {
+				return cal.get(java.util.Calendar.DST_OFFSET);
+			}
+			public int getTimezoneOffset() {
+				return cal.get(java.util.Calendar.ZONE_OFFSET);
+			}
+			
+		}
+	]]></zscript>
+<label multiline="true">
+	* java 1.8 144, GMT-5
+	* java 1.8 362, GMT-6
+</label>
+	<grid viewModel="@id('vm') @init('ViewModel')" sizedByContent="true">
+		<columns>
+			<column hflex="false"/>
+			<column hflex="1"/>
+		</columns>
+		<rows>
+			<row>
+				<label value="Java System Date" hflex="false"/>
+				<label value="${vm.date}" hflex="1"/>
+			</row>
+			<row>
+				<label value="Java Formated Date" hflex="false"/>
+				<label value="${vm.formatedDate}" hflex="1"/>
+			</row>
+			<row>
+				<label value="Locale" hflex="false"/>
+				<label value="${vm.locale}" hflex="1"/>
+			</row>
+			<row>
+				<label value="Timezone" hflex="false"/>
+				<textbox value="${vm.timezone}" hflex="1" multiline="true" rows="3"/>
+			</row>
+			<row>
+				<label value="DST Offset" hflex="false"/>
+				<label value="${vm.dstOffset}" hflex="1"/>
+			</row>
+			<row>
+				<label value="Timezone Offset" hflex="false"/>
+				<label value="${vm.timezoneOffset}" hflex="1"/>
+			</row>
+			<row>
+				<label value="ZK datebox" hflex="false"/>
+				<datebox value="${vm.date}" format="yyyy-MM-dd HH:mm:ss" hflex="1" />
+			</row>
+		</rows>
+	</grid>
+	<script><![CDATA[
+function getOffset(area){
+	return zk.mm().tz(area).utcOffset()/60;
+}
+	]]></script>
+	offset in moment.js
+	see https://gist.github.com/diogocapela/12c6617fc87607d11fd62d2a4f42b02a
+	<hlayout>
+		<label value="America/Mexico_City"/> <label w:onAfterSize="this.setValue(getOffset(this.previousSibling.getValue()))"/>
+	</hlayout>
+	<hlayout>
+		<label value="Mexico/BajaNorte"/> <label w:onAfterSize="this.setValue(getOffset(this.previousSibling.getValue()))"/>
+	</hlayout>
+	<hlayout>
+		<label value="Mexico/BajaSur"/> <label w:onAfterSize="this.setValue(getOffset(this.previousSibling.getValue()))"/>
+	</hlayout>
+	<hlayout>
+		<label value="Mexico/General"/> <label w:onAfterSize="this.setValue(getOffset(this.previousSibling.getValue()))"/>
+	</hlayout>
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -3127,6 +3127,7 @@ B90-ZK-4431.zul=A,E,Multislider
 ##zats##B96-ZK-5133.zul=A,E,radio,onPageAttached,radiogroup
 ##manually##B96-ZK-5430.zul=A,camera,dimension,ratio
 ##manually##B96-ZK-3246.zul=A,E,Filedownload,IOS
+##zats##B96-ZK-5434.zul=A,E,timezone,momentjs,Datebox
 
 ##
 # Features - 3.0.x version

--- a/zktest/test/java/org/zkoss/zktest/zats/test2/B96_ZK_5434Test.java
+++ b/zktest/test/java/org/zkoss/zktest/zats/test2/B96_ZK_5434Test.java
@@ -1,0 +1,25 @@
+package org.zkoss.zktest.zats.test2;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import org.junit.Test;
+
+import org.zkoss.zktest.zats.WebDriverTestCase;
+
+public class B96_ZK_5434Test extends WebDriverTestCase {
+	@Test
+	public void test() {
+		connect();
+		waitResponse();
+
+		final String tzIdentifier = "America/Mexico_City";
+		final float momentjsUtcOffsetInHours = Float.parseFloat(getEval("getOffset('" + tzIdentifier + "')"));
+		final int javaUtcOffsetInSeconds = OffsetDateTime.now(ZoneId.of(tzIdentifier)).getOffset().getTotalSeconds();
+		// Don't use `assertEquals` to compare floating-point numbers.
+		assertTrue(javaUtcOffsetInSeconds == momentjsUtcOffsetInHours * 3600);
+		assertEquals(javaUtcOffsetInSeconds, -6 * 3600); // The UTC offset should be -6 as of Apr 24, 2023.
+	}
+}


### PR DESCRIPTION
The UTC offset should be -6 for America/Mexico_City.