### PR TITLE
ZK-5368: Tree with client-ROD fails to replace treerow if parent is currently not rendered

### DIFF
--- a/@types/zk/zk.d.ts
+++ b/@types/zk/zk.d.ts
@@ -171,10 +171,11 @@ declare namespace zk {
         appendChild(child: Widget, ignoreDom?: boolean): boolean;
         beforeParentChanged_(newparent: Widget): void;
         beforeSendAU_(wgt: Widget, evt: Event): void;
-        bind_(dt?: Desktop| null, skipper?: Skipper | null, after?: (() => void)[]): void;
-        bind(dt?: Desktop| null, skipper?: Skipper | null): void;
+        bind_(dt?: Desktop| null, skipper?: Skipper | null, after?: (() => void)[], bindSelfOnly?: boolean): void;
+        bind(dt?: Desktop| null, skipper?: Skipper | null, bindSelfOnly?: boolean): this;
         bindChildren_(dt?: Desktop| null, skipper?: Skipper| null, after?: (() => void)[]): void;
         bindDoubleTap_(): void;
+        bindMissingAncestors(desktop?: zk.Desktop | null, skipper?: zk.Skipper | null): this;
         bindSwipe_(): void;
         bindTapHold_(): void;
         canActivate(opts?: {checkOnly?: boolean}): boolean;
@@ -327,7 +328,7 @@ declare namespace zk {
         show(): Widget;
         smartUpdate(name: string, value: any, timeout?: number): Widget;
         unbind_(skipper?: Skipper | null, after?: (() => void)[], keepRod?: boolean): void;
-        unbind(skipper?: Skipper | null, keepRod?: boolean): Widget;
+        unbind(skipper?: Skipper | null, keepRod?: boolean): this;
         unbindChildren_(skipper?: Skipper, after?: (() => void)[], keepRod?: boolean): void;
         unbindDoubleTap_(): void;
         unbindSwipe_(): void;

--- a/zk/src/archive/web/js/zk/widget.ts
+++ b/zk/src/archive/web/js/zk/widget.ts
@@ -3064,6 +3064,22 @@ function () {
 	rerenderNow_: function (skipper) { // for Bug ZK-2281 and others life cycle issues when the dom of children of itself is undefined.
 		_rerenderNow(this, skipper);
 	},
+	/**
+	 * Recursively bind ancestors that are currently unbound (i.e., `desktop` is falsy). Used by ROD.
+	 * Introduced by ZK-5368.
+	 * @param zk.Desktop desktop [optional] the desktop the DOM element belongs to.
+	 * If not specified, ZK will decide it automatically.
+	 * @param zk.Skipper skipper [optional] used if {@link #rerender} is called with a non-null skipper.
+	 * @since 9.6.4
+	 */
+	bindMissingAncestors: function (desktop, skipper) {
+		const { parent } = this;
+		if (parent && !parent.desktop) {
+			// `skipper` for this widget and its descendents shouldn't affect that of ancestors.
+			parent.bind(desktop, skipper, true).bindMissingAncestors(desktop);
+		}
+		return this;
+	},
 	/** Binds this widget.
 	 * It is called to associate (aka., attach) the widget with
 	 * the DOM tree.
@@ -3075,20 +3091,21 @@ function () {
 	 *
 	 * @see #bind_
 	 * @see #unbind
-	 * @param zk.Desktop dt [optional] the desktop the DOM element belongs to.
+	 * @param zk.Desktop desktop [optional] the desktop the DOM element belongs to.
 	 * If not specified, ZK will decide it automatically.
 	 * @param zk.Skipper skipper [optional] used if {@link #rerender} is called with a non-null skipper.
+	 * @param boolean bindSelfOnly [optional] set to true if one doesn't want to recursively bind descendents.
 	 * @return zk.Widget this widget
 	 */
-	bind: function (desktop, skipper) {
+	bind: function (desktop, skipper, bindSelfOnly) {
 		this._binding = true;
 
 		_rerenderDone(this, skipper); //cancel pending async rerender
-		if (this.z_rod)
+		if (this.z_rod && !bindSelfOnly)
 			this.$class._bindrod(this);
 		else {
 			var after = [], fn;
-			this.bind_(desktop, skipper, after);
+			this.bind_(desktop, skipper, after, bindSelfOnly);
 			while (fn = after.shift())
 				fn();
 		}
@@ -3106,8 +3123,6 @@ function () {
 	 *
 	 * @see #unbind_
 	 * @see #bind
-	 * @param zk.Desktop dt [optional] the desktop the DOM element belongs to.
-	 * If not specified, ZK will decide it automatically.
 	 * @param zk.Skipper skipper [optional] used if {@link #rerender} is called with a non-null skipper.
 	 * @param boolean keepRod [optional] used if the ROD flag needs to be kept.
 	 * @return zk.Widget this widget
@@ -3155,8 +3170,9 @@ bind_: function (desktop, skipper, after) {
   });
 }
 </code></pre>
+	 * @param boolean bindSelfOnly [optional] set to true if one doesn't want to recursively bind descendents.
 	 */
-	bind_: function (desktop, skipper, after) {
+	bind_: function (desktop, skipper, after, bindSelfOnly) {
 		this.$class._bind0(this);
 
 		this.desktop = desktop || (desktop = zk.Desktop.$(this.parent));
@@ -3169,8 +3185,8 @@ bind_: function (desktop, skipper, after) {
 		
 		if (this._nvflex || this._nhflex)
 			_listenFlex(this);
-
-		this.bindChildren_(desktop, skipper, after);
+		if (!bindSelfOnly)
+			this.bindChildren_(desktop, skipper, after);
 		var self = this;
 		if (this.isListen('onBind')) {
 			zk.afterMount(function () {

--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -28,6 +28,7 @@ ZK 9.6.4
   ZK-5429: tabbox scroll unsynced when resizing with toolbar
   ZK-5433: tabbox doesn't scroll the selected tab into the current view when shrinking its width
   ZK-5432: aria-activedescendant is generated at wrong place
+  ZK-5368: Tree with client-ROD fails to replace treerow if parent is currently not rendered
 
 * Upgrade Notes
   + Upgrade JRuby dependency from 1.1.2 to 1.7.27 for some security vulnerabilities

--- a/zktest/src/archive/test2/B96-ZK-5368.zul
+++ b/zktest/src/archive/test2/B96-ZK-5368.zul
@@ -1,0 +1,28 @@
+<zk>
+	<div height="600px" width="600px" viewModel="@id('vm') @init('org.zkoss.zktest.test2.B96_ZK_5368VM')">
+		<button label="toggle" onClick="@command('toggle')"/>
+		<button label="refresh" onClick="@command('refresh')"/>
+		<button label="remove" onClick="@command('remove')"/>
+		<checkbox checked="@load(vm.show)"/>
+		<if test="@load(vm.show)">
+			<tree model="@load(vm.treeModel)" renderdefer="100" hflex="1" id="tree" height="500px"
+			      onCreate='Events.echoEvent(new Event("onFoo", self));'
+			      onFoo="@command('refresh')">
+				<custom-attributes  org.zkoss.zul.tree.maxRodPageSize="5"/>
+				<treecols>
+					<treecol width="85%"/>
+					<treecol width="15%"/>
+				</treecols>
+				<template name="model">
+					<treeitem open="true" onClick="@command('update',target=each)">
+						<treerow>
+							<treecell>
+								<label value="@load(each)"/>
+							</treecell>
+						</treerow>
+					</treeitem>
+				</template>
+			</tree>
+		</if>
+	</div>
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -3133,6 +3133,7 @@ B90-ZK-4431.zul=A,E,Multislider
 ##zats##B96-ZK-5429.zul=A,E,scroll,resize,tab,selection
 ##zats##B96-ZK-5433.zul=A,E,scroll,resize,tab,selection
 ##manually##B96-ZK-5432.zul=A,E,a11y,activedescendant
+##zats##B96-ZK-5368.zul=A,E,tree,treechildren,treerow,ROD
 
 ##
 # Features - 3.0.x version

--- a/zktest/src/org/zkoss/zktest/test2/B96_ZK_5368VM.java
+++ b/zktest/src/org/zkoss/zktest/test2/B96_ZK_5368VM.java
@@ -1,0 +1,74 @@
+package org.zkoss.zktest.test2;
+
+import java.util.Collections;
+
+import org.zkoss.bind.annotation.BindingParam;
+import org.zkoss.bind.annotation.Command;
+import org.zkoss.bind.annotation.Init;
+import org.zkoss.bind.annotation.NotifyChange;
+import org.zkoss.zul.DefaultTreeModel;
+import org.zkoss.zul.DefaultTreeNode;
+
+public class B96_ZK_5368VM {
+
+	private boolean show;
+
+	private DefaultTreeModel treeModel;
+
+	public DefaultTreeModel getTreeModel() {
+		return treeModel;
+	}
+
+	public void setTreeModel(DefaultTreeModel treeModel) {
+		this.treeModel = treeModel;
+	}
+
+	@Init
+	public void init() {
+		DefaultTreeNode<String> root = new DefaultTreeNode<>("root", Collections.emptyList());
+		treeModel = new DefaultTreeModel(root);
+		recursivelyFillNodes(root, "item-", 3);
+		this.show = true;
+	}
+
+	private void recursivelyFillNodes(DefaultTreeNode node, String label, int i) {
+		for (int j = 0; j < 5; j++) {
+			DefaultTreeNode child = new DefaultTreeNode(label + j, Collections.emptyList());
+			node.add(child);
+			treeModel.addOpenObject(child);
+			if (i > 0)
+				recursivelyFillNodes(child, (String) child.getData(), i - 1);
+		}
+	}
+
+	public boolean isShow() {
+		return show;
+	}
+
+	public void setShow(boolean show) {
+		this.show = show;
+	}
+
+	@NotifyChange("*")
+	@Command
+	public void refresh() {
+	}
+
+	@NotifyChange("show")
+	@Command
+	public void toggle() {
+		show = !show;
+	}
+
+	@NotifyChange("show")
+	@Command
+	public void remove() {
+		final DefaultTreeNode root = (DefaultTreeNode) treeModel.getRoot();
+		root.remove(root.getChildAt(0));
+	}
+
+	@Command
+	public void update(@BindingParam("target") DefaultTreeNode target) {
+		target.setData(target.getData() + "-foo");
+	}
+}

--- a/zktest/test/java/org/zkoss/zktest/zats/test2/B96_ZK_5368Test.java
+++ b/zktest/test/java/org/zkoss/zktest/zats/test2/B96_ZK_5368Test.java
@@ -1,0 +1,33 @@
+package org.zkoss.zktest.zats.test2;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import org.zkoss.zktest.zats.WebDriverTestCase;
+import org.zkoss.zktest.zats.ztl.JQuery;
+
+public class B96_ZK_5368Test extends WebDriverTestCase {
+	@Test
+	public void test() {
+		connect();
+		waitResponse();
+		final JQuery treeBody = jq(".z-tree-body");
+		// Scroll to bottom to get item44 into DOM.
+		treeBody.scrollTop(Integer.parseInt(treeBody.toElement().get("scrollHeight")));
+		waitResponse();
+		// Then, scroll item44 into view.
+		eval("jq('[aria-label=\" item-44\"]')[0].scrollIntoView()");
+		waitResponse();
+		// Click item44 and make sure its label is appended with "-foo".
+		click(selectByAriaLabel(" item-44")); // Note the leading space character.
+		waitResponse();
+		// Note the leading space character and that the aria label has changed.
+		final String label = " item-44-foo";
+		assertEquals(label, selectByAriaLabel(label).text());
+	}
+
+	private JQuery selectByAriaLabel(String ariaLabel) {
+		return jq("[aria-label=\"" + ariaLabel + "\"]");
+	}
+}


### PR DESCRIPTION
This PR should be merged alongside [ZK#995](https://github.com/zkoss/zkcml/pull/995).