### PR TITLE
ZK-5258: setFocus() doesn't work on a textbox in a modal window

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -30,6 +30,7 @@ ZK 9.6.4
   ZK-5432: aria-activedescendant is generated at wrong place
   ZK-5368: Tree with client-ROD fails to replace treerow if parent is currently not rendered
   ZK-5252: a modal window doesn't focus on its first focusable child
+  ZK-5258: setFocus() doesn't work on a textbox in a modal window
 
 * Upgrade Notes
   + Upgrade JRuby dependency from 1.1.2 to 1.7.27 for some security vulnerabilities

--- a/zktest/src/archive/test2/B96-ZK-5258.zul
+++ b/zktest/src/archive/test2/B96-ZK-5258.zul
@@ -1,0 +1,14 @@
+<zk>
+	<button label="show modal" onClick="showModal()"/>
+	<zscript><![CDATA[
+public void showModal(){
+	Window w = new Window();
+	w.setPage(page);
+	w.appendChild(new Toolbarbutton("get focus"));
+	Textbox box1 = new Textbox();
+	w.appendChild(box1);
+	box1.setFocus(true);
+	w.doModal();
+}
+ ]]></zscript>
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -3135,6 +3135,7 @@ B90-ZK-4431.zul=A,E,Multislider
 ##manually##B96-ZK-5432.zul=A,E,a11y,activedescendant
 ##zats##B96-ZK-5368.zul=A,E,tree,treechildren,treerow,ROD
 ##zats##B96-ZK-5252.zul=A,E,modal,focus,TypeScript
+##zats##B96-ZK-5258.zul=A,E,modal,focus,TypeScript
 
 ##
 # Features - 3.0.x version

--- a/zktest/test/java/org/zkoss/zktest/zats/test2/B96_ZK_5258Test.java
+++ b/zktest/test/java/org/zkoss/zktest/zats/test2/B96_ZK_5258Test.java
@@ -1,0 +1,22 @@
+package org.zkoss.zktest.zats.test2;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.zkoss.zktest.zats.WebDriverTestCase;
+
+/**
+ * @see org.zkoss.zktest.zats.test2.B96_ZK_5252Test
+ */
+public class B96_ZK_5258Test extends WebDriverTestCase {
+	@Test
+	public void test() {
+		connect();
+		waitResponse();
+		// Open the modal.
+		click(jq("@button"));
+		waitResponse();
+		// Make sure that the text box regains focus.
+		Assert.assertEquals("true", getEval("jq('.z-textbox')[0] === document.activeElement"));
+	}
+}


### PR DESCRIPTION
This PR builds on [ZK#2944](https://github.com/zkoss/zk/pull/2944). Please merge that first.