### PR TITLE
ZK-5414: onTimer event causes a cascader to close its next level items

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -35,6 +35,7 @@ ZK 9.6.4
   ZK-5258: setFocus() doesn't work on a textbox in a modal window
   ZK-5076: Listbox in select mold setModel + set selectedIndex causes unsync selection state
   ZK-5427: missing context menu after ZK-4835 on hybrid mouse / touch devices
+  ZK-5414: onTimer event causes a cascader to close its next level items
 
 * Upgrade Notes
   + Upgrade JRuby dependency from 1.1.2 to 1.7.27 for some security vulnerabilities

--- a/zktest/src/archive/test2/B96-ZK-5414.zul
+++ b/zktest/src/archive/test2/B96-ZK-5414.zul
@@ -1,0 +1,15 @@
+<zk xmlns:h="native">
+	<h:h1>Basic</h:h1>
+	<zscript><![CDATA[
+	DefaultTreeModel treeModel = new DefaultTreeModel(new DefaultTreeNode("ROOT",
+		Arrays.asList(new DefaultTreeNode[]{
+			new DefaultTreeNode("USA", Arrays.asList(new TreeNode[]{new DefaultTreeNode("New York"),new DefaultTreeNode("Los Angelas")})),
+			new DefaultTreeNode("Japan", Arrays.asList(new TreeNode[]{new DefaultTreeNode("Tokyo"),new DefaultTreeNode("Kyoto")})),
+			new DefaultTreeNode("New Zealand", Arrays.asList(new TreeNode[]{new DefaultTreeNode("Auckland"),new DefaultTreeNode("Queenstown")}))
+		})
+	));
+    ]]></zscript>
+	<cascader id="cas" width="300px" model="${treeModel}" onSelect="result.setValue(self.getSelectedItem().toString());"/>
+	<label id="result"/>
+	<timer repeats="true" delay="1000" onTimer="" />
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -3140,6 +3140,7 @@ B90-ZK-4431.zul=A,E,Multislider
 ##zats##B96-ZK-5258.zul=A,E,modal,focus,TypeScript
 ##zats##B96-ZK-5076.zul=A,E,select,option,listmodel
 ##manually##B96-ZK-5427.zul=A,E,touch,context,mouse
+##zats##B96-ZK-5414.zul=A,E,timer,cascader
 
 ##
 # Features - 3.0.x version

--- a/zktest/test/java/org/zkoss/zktest/zats/test2/B96_ZK_5414Test.java
+++ b/zktest/test/java/org/zkoss/zktest/zats/test2/B96_ZK_5414Test.java
@@ -1,0 +1,21 @@
+package org.zkoss.zktest.zats.test2;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import org.zkoss.zktest.zats.WebDriverTestCase;
+
+public class B96_ZK_5414Test extends WebDriverTestCase {
+	@Test
+	public void test() {
+		connect();
+		waitResponse();
+
+		click(jq("@cascader"));
+		waitResponse();
+		click(jq("li:contains(\"USA\")"));
+		waitResponse(3000); // Wait a few seconds for timer to take effect.
+		assertTrue(jq("li:contains(\"New York\")").exists());
+	}
+}


### PR DESCRIPTION
This PR should be merge alongside [zkcml#998](https://github.com/zkoss/zkcml/pull/998).