### PR TITLE
Revert ZK-5260.

### DIFF
--- a/zktest/src/org/zkoss/zktest/test2/B96_ZK_5260VM.java
+++ b/zktest/src/org/zkoss/zktest/test2/B96_ZK_5260VM.java
@@ -9,7 +9,11 @@ public class B96_ZK_5260VM {
 		model.add("1@email.io");
 		model.add("2@email.io");
 		model.add("3@email.io");
-		model.add("4@email.io <aerror");
+		// Escape the string manually because
+		// "`ItemRenderer::render` renders the data to the corresponding HTML fragment, and returns the HTML `fragment.model."
+		// See https://www.zkoss.org/javadoc/latest/zk/org/zkoss/zul/ItemRenderer.html
+		// Also see ZK-2691.
+		model.add("4@email.io &lt;aerror");
 		model.add("5@email.io");
 		model.add("6@email.io");
 		model.add("7@email.io");


### PR DESCRIPTION
This PR shoudl be merged alongside [zkcml#1002](https://github.com/zkoss/zkcml/pull/1002).

Unconditionally escaping strings in ZK-5260 conflicts with the documentation for ItemRenderer::render and ZK-2691.

`model.add("4@email.io <aerror");` should be allowed because "`ItemRenderer::render` renders the data to the corresponding HTML fragment, and returns the HTML `fragment.model." See https://www.zkoss.org/javadoc/latest/zk/org/zkoss/zul/ItemRenderer.html