### PR TITLE
ZK-5373, ZK-5448, ZK-5449, ZK-5462 and ZK-5463 fixed, give focus element aria-label attribute and "rowgroup" role

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -8,6 +8,11 @@ ZK 10.0.0
   ZK-5270: Adjust ID generation mechanism in ZHTML Component
 
 * Bugs
+  ZK-5373: focus button, z-focus-a, doesn't have an accessible name
+  ZK-5448: Elements with an ARIA treegrid(role) that require children to contain a specific row(role) are missing some or all of those required children
+  ZK-5449: Elements with an ARIA treegrid(role) that require children to contain a specific [role] are missing some or all of those required children
+  ZK-5462: empty listbox fails to pass lighthouse accessibility check for missing required role
+  ZK-5463: empty tree fails to pass lighthouse accessibility check for missing required role
   ZK-5089: AfterSizeEvent doesn't return a correct size of a Window component
   ZK-5120: Combobox smart update emptySearchMessage doesn't work
   ZK-5138: Grid row setAlign not work after rendered


### PR DESCRIPTION
Screen readers do not read the name of this aria-label, they read the name of the focused element.
Additionally, the role of a listbox is "grid", and the role of a tree is "treegrid", since this focus button will be their first descendant, it must have a "rowgroup" role in order to pass the Lighthouse accessibility audit, so I also added role="rowgroup" to them here.
Although only the listbox is reported as an error in ZK-5373 , the issue is the same for tree too, so I have made the necessary modifications here to address the problem.
And this is also the cause of ZK-5448 , ZK-5449 , ZK-5462 , ZK-5463.