### PR TITLE
ZK-5373: focus button, z-focus-a, doesn't have an accessible name

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -20,6 +20,7 @@ ZK 10.0.0
   ZK-5454: nextSibling locator doesn't work in smartUpdate()
   ZK-5261: forEach always re-renders all items
   ZK-5493: [user-scalable='no'] is used in the <meta name='viewport'> element or the [maximum-scale] attribute is less than 5
+  ZK-5373: focus button, z-focus-a, doesn't have an accessible name
 
 
 * Upgrade Notes


### PR DESCRIPTION
This PR should be merge alongside zkoss/zkcml#1008.