### PR TITLE
ZK-5462: empty listbox fails to pass lighthouse accessibility check for missing required role

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -24,6 +24,7 @@ ZK 10.0.0
   ZK-5448: Elements with an ARIA treegrid(role) that require children to contain a specific row(role) are missing some or all of those required children
   ZK-5449: Elements with an ARIA treegrid(role) that require children to contain a specific [role] are missing some or all of those required children
   ZK-5463: empty tree fails to pass lighthouse accessibility check for missing required role
+  ZK-5462: empty listbox fails to pass lighthouse accessibility check for missing required role
 
 
 * Upgrade Notes


### PR DESCRIPTION
This PR should be merge alongside zkoss/zkcml#1011.