### PR TITLE
ZK-5488: Biglistbox's Elements with an ARIA [role] that require children to contain a specific [role] are missing some or all of those required children

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -32,6 +32,7 @@ ZK 10.0.0
   ZK-5494: Background and foreground colors do not have a sufficient contrast ratio
   ZK-5481: The checkbox in a listitem doesn't have a role "checkbox"
   ZK-5257: Ignore unused component NoClassDefFoundError such as jasperreport component
+  ZK-5488: Biglistbox's Elements with an ARIA [role] that require children to contain a specific [role] are missing some or all of those required children
 
 
 * Upgrade Notes


### PR DESCRIPTION
This PR should be merge alongside zkoss/zkcml#1013.