### PR TITLE
ZK-5489: Linelayout's Elements with an ARIA [role] that require children to contain a specific [role] are missing some or all of those required children

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -37,6 +37,7 @@ ZK 10.0.0
   ZK-5450: 2 NEXT_SIBLING for targetId don't pass the expected value
   ZK-5435: desktop timeout config doesn't work as expected
   ZK-5498: Some checkboxes do not have [aria-checked] attribute, and they do not have accessible names
+  ZK-5489: Linelayout's Elements with an ARIA [role] that require children to contain a specific [role] are missing some or all of those required children
 
 
 * Upgrade Notes


### PR DESCRIPTION
This PR should be merge alongside zkoss/zkcml#1014.