### PR TITLE
ZK-5490: Grid's [aria-*] attributes do not match their roles

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -41,6 +41,7 @@ ZK 10.0.0
   ZK-5489: Linelayout's Elements with an ARIA [role] that require children to contain a specific [role] are missing some or all of those required children
   ZK-5017: Listbox head flickering caused by onClientInfo
   ZK-5468: Components with Model only renders one item with wrong result if the EL contains forEachStatus.index
+  ZK-5490: Grid's [aria-*] attributes do not match their roles
 
 
 * Upgrade Notes


### PR DESCRIPTION
This PR should be merge alongside zkoss/zkcml#1015.