### PR TITLE
ZK-5412: Desktop of stateless components is not cleared after reloadi…

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -33,6 +33,7 @@ ZK 10.0.0
   ZK-5481: The checkbox in a listitem doesn't have a role "checkbox"
   ZK-5257: Ignore unused component NoClassDefFoundError such as jasperreport component
   ZK-5488: Biglistbox's Elements with an ARIA [role] that require children to contain a specific [role] are missing some or all of those required children
+  ZK-5412: Desktop of stateless components is not cleared after reloading [CloudMode]
 
 
 * Upgrade Notes

--- a/zktest/build.gradle
+++ b/zktest/build.gradle
@@ -115,7 +115,7 @@ dependencies {
 	testImplementation 'org.eclipse.jetty:apache-jsp:10.0.11'
 	testImplementation 'org.junit.platform:junit-platform-launcher:1.9.0'
 	testImplementation 'xml-apis:xml-apis:1.4.01'
-	testImplementation 'org.zkoss.test:zk-webdriver:1.0.9.1'
+	testImplementation 'org.zkoss.test:zk-webdriver:1.0.9.2'
 
 	// For B96_ZK_4194Test to use a specific Chrome driver version (this will change to match latest chrome)
 	testImplementation 'org.seleniumhq.selenium:selenium-devtools-v112:4.9.0'


### PR DESCRIPTION
…ng [CloudMode]
The PR should be merged alongside https://github.com/zkoss/zkcml/pull/1037