### PR TITLE
ZK-5525: Checkbox tristate [aria-checked] attribute missing "mixed" state

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -45,6 +45,7 @@ ZK 10.0.0
   ZK-5017: Listbox head flickering caused by onClientInfo
   ZK-5468: Components with Model only renders one item with wrong result if the EL contains forEachStatus.index
   ZK-5490: Grid's [aria-*] attributes do not match their roles
+  ZK-5525: Checkbox tristate [aria-checked] attribute missing "mixed" state
 
 
 * Upgrade Notes


### PR DESCRIPTION
This PR should be merge alongside zkoss/zkcml#1046.