### PR TITLE
Revert ZK-5026 to fix ZK-5235: Opening a menupopup moves a scrollbar of a long menu back to top

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -47,6 +47,7 @@ ZK 10.0.0
   ZK-5468: Components with Model only renders one item with wrong result if the EL contains forEachStatus.index
   ZK-5490: Grid's [aria-*] attributes do not match their roles
   ZK-5525: Checkbox tristate [aria-checked] attribute missing "mixed" state
+  ZK-5235: Opening a menupopup moves a scrollbar of a long menu back to top
 
 
 * Upgrade Notes
@@ -64,6 +65,7 @@ ZK 10.0.0
   by a timer per session if the setting is enabled. (By default, it's enabled with 1 hour)
   To disable the cleaner timer per session, you can specify -1 to the desktop timeout
   value to disable the mechanism.
+  + Revert ZK-5026 which the original bug cannot be reproduced to fix ZK-5235.
 
    --------
 ZK 9.6.4

--- a/zktest/src/main/webapp/test2/B100-ZK-5235.zul
+++ b/zktest/src/main/webapp/test2/B100-ZK-5235.zul
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+B100-ZK-5235.zul
+
+        Purpose:
+
+        Description:
+
+        History:
+                Thu Aug 17 17:24:19 CST 2023, Created by rebeccalai
+
+Copyright (C) 2023 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+    <label multiline="true">
+        1. scroll down to hover on the "last" menu and wait for the menupopup to show
+        2. the scroll bar stays at the current position (if bug exists then goes back to the top)
+    </label>
+    <menubar>
+        <menu id="longMenu" label="long menu">
+            <menupopup>
+                <forEach begin="1" end="50">
+                    <menuitem label="${each}"/>
+                </forEach>
+                <menu id="childMenu" label="last">
+                    <menupopup>
+                        <menuitem label="inner item"/>
+                    </menupopup>
+                </menu>
+            </menupopup>
+        </menu>
+    </menubar>
+</zk>

--- a/zktest/src/main/webapp/test2/config.properties
+++ b/zktest/src/main/webapp/test2/config.properties
@@ -3169,6 +3169,7 @@ B90-ZK-4431.zul=A,E,Multislider
 ##zats##B100-ZK-5468-Stepbar.zul=A,E,Model,Stepbar
 ##zats##B100-ZK-5468-Tabbox.zul=A,E,Model,Tabbox
 ##zats##B100-ZK-5468-Tree.zul=A,E,Model,Tree
+##zats##B100-ZK-5235.zul=A,E,Menu,Menupopup,focus
 
 ##
 # Features - 3.0.x version

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B100_ZK_5235Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B100_ZK_5235Test.java
@@ -1,0 +1,37 @@
+/* B100_ZK_5235Test.java
+
+        Purpose:
+                
+        Description:
+                
+        History:
+                Mon Aug 21 13:04:26 CST 2023, Created by rebeccalai
+
+Copyright (C) 2023 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.interactions.Actions;
+
+import org.zkoss.test.webdriver.WebDriverTestCase;
+
+/**
+ * @author rebeccalai
+ */
+public class B100_ZK_5235Test extends WebDriverTestCase {
+    @Test
+    public void test() {
+        Actions act = new Actions(connect());
+
+        click(jq("$longMenu"));
+        waitResponse();
+        assertTrue(jq(".z-menupopup-open").isVisible());
+
+        act.moveToElement(toElement(jq("$childMenu"))).perform();
+        waitResponse();
+        assertTrue(jq("$childMenu").hasClass("z-menu-hover"));
+    }
+}

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B96_ZK_5026Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B96_ZK_5026Test.java
@@ -19,6 +19,7 @@ import org.openqa.selenium.Keys;
 import org.openqa.selenium.interactions.Actions;
 
 import org.zkoss.test.webdriver.WebDriverTestCase;
+import org.zkoss.test.webdriver.ztl.JQuery;
 
 /**
  * @author jumperchen
@@ -55,10 +56,11 @@ public class B96_ZK_5026Test extends WebDriverTestCase {
 				.perform();
 
 		assertTrue(jq(" .z-menuitem.z-menuitem-hover").exists());
+		JQuery childMenupopup = jq(".z-menupopup-content").eq(1);
 		act.sendKeys(Keys.DOWN).perform();
-		assertTrue(jq(".z-menupopup-content > .z-menuitem:nth-child(2)").hasClass("z-menuitem-hover"));
+		assertTrue(childMenupopup.children(".z-menuitem:first-child").hasClass("z-menuitem-hover"));
 
 		act.sendKeys(Keys.DOWN).perform();
-		assertTrue(jq(".z-menupopup-content > .z-menuitem:nth-child(3)").hasClass("z-menuitem-hover"));
+		assertTrue(childMenupopup.children(".z-menuitem:nth-child(2)").hasClass("z-menuitem-hover"));
 	}
 }

--- a/zul/src/main/resources/web/js/zul/menu/Menupopup.ts
+++ b/zul/src/main/resources/web/js/zul/menu/Menupopup.ts
@@ -564,10 +564,6 @@ export class Menupopup extends zul.wgt.Popup {
 
 	/** @internal */
 	addActive_(wgt: zk.Widget): void {
-		// ZK-5026
-		if (zk.currentFocus != this) {
-			this.getAnchor_()?.focus();
-		}
 		this._curIndex = _indexOfVisibleMenu(this, wgt);
 	}
 


### PR DESCRIPTION
Since the original ZK-5026 bug cannot be reproduced, revert ZK-5026 to fix ZK-5235.