### PR TITLE
Fix Datebox.getTimeFormat() for format consistency

### DIFF
--- a/zul/src/main/resources/web/js/zul/db/Datebox.ts
+++ b/zul/src/main/resources/web/js/zul/db/Datebox.ts
@@ -636,17 +636,21 @@ export class Datebox extends zul.inp.FormatWidget<DateImpl> {
 			mv = mm > -1 ? 'mm' : '',
 			sv = ss > -1 ? 'ss' : '';
 
+		// Differentiate single/double 'h' and whether there is a space before/after 'a'
+		// to ensure the extracted time format matches the original format
 		if (hasHour1) {
-			var time = Datebox._prepareTimeFormat(hh < KK ? 'KK' : 'hh', mv, sv);
+			const hv = (hh == -1 || fmt.includes('hh')) ? 'hh' : 'h';
+			var time = Datebox._prepareTimeFormat(hh < KK ? 'KK' : hv, mv, sv);
 			if (aa == -1)
 				return time;
 			else if ((hh != -1 && aa < hh) || (KK != -1 && aa < KK))
-				return 'a ' + time;
+				return (fmt.includes('a ') ? 'a ' : 'a') + time;
 			else
-				return time + ' a';
-		} else
-			return Datebox._prepareTimeFormat(HH < kk ? 'kk' : HH > -1 ? 'HH' : '', mv, sv);
-
+				return time + (fmt.includes(' a') ? ' a' : 'a');
+		} else {
+			const hv = (HH == -1 || fmt.includes('HH')) ? 'HH' : 'H';
+			return Datebox._prepareTimeFormat(HH < kk ? 'kk' : HH > -1 ? hv : '', mv, sv);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Differentiate single/double 'h' and whether there is a space before/after 'a' to fix the time format inconsistency observed in `B60-ZK-1341.zul` (datebox time format = `ah:mm:ss` but the time format extracted by its `getTimeFormat()` used as timebox format = `a hh:mm:ss`). After the fix, the behavior is still different from 9.6.4 which both datebox and timebox time format = `a hh:mm:ss`, but the correct time format should be `ah:mm:ss` according to the `complete.js` file.