### PR TITLE
ZK-5605: client-bind fails for zk.$extends created widget classes, wi…

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -20,6 +20,7 @@ ZK 10.0.0
   ZK-5569: Radiogroup onCheck event type mismatch
   ZK-5161: page directive's attributes are not encoded before rendering into HTML
   ZK-5598: CKEditor requests ExecutionImpl.encodeURL with null value, causes NPE in embedded mode
+  ZK-5605: client-bind fails for zk.$extends created widget classes, without ClientBindComposer declared
 
 * Upgrade Notes
   + Upgrade commons-fileupload to commons-fileupload2-javax 2.0.0-M1 and commons-io to 2.13.0 to support jakarta-friendly uploads

--- a/zktest/src/main/webapp/test2/config.properties
+++ b/zktest/src/main/webapp/test2/config.properties
@@ -3111,6 +3111,7 @@ B90-ZK-4431.zul=A,E,Multislider
 ##zats##B100-ZK-5161.zul=A,E,XSS,Security,Page
 ##Manually##B100-ZK-5598.zul=A,E,CKEditor,Embedded,NPE
 ##manully##F100-ZK-5596.zul=A,E,Embedded,Url
+##zats##B100-ZK-5605.zul=A,E,clientbind,widget
 
 ##
 # Features - 3.0.x version


### PR DESCRIPTION
…thout ClientBindComposer declared

This PR should be merge alongside zkoss/zkcml#1110