### PR TITLE
Refine B100_ZK_5650Test

### DIFF
--- a/zktest/build.gradle
+++ b/zktest/build.gradle
@@ -110,7 +110,7 @@ dependencies {
 	runtimeOnly 'org.mozilla:rhino:1.7.14'
 //	testImplementation 'org.jruby:jruby-core:1.7.27'
 	runtimeOnly 'org.python:jython:2.2.1'
-	testImplementation 'org.zkoss.zats:zats-mimic-ext:10.0.0-FL-2022070817'
+	testImplementation 'org.zkoss.zats:zats-mimic-ext:10.0.0'
 	testImplementation 'net.jcip:jcip-annotations:1.0'
 	testImplementation 'com.deque.html.axe-core:selenium:4.7.0'
 	testImplementation 'org.springframework.session:spring-session-core:2.1.6.RELEASE'

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B100_ZK_5650Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B100_ZK_5650Test.java
@@ -33,6 +33,7 @@ public class B100_ZK_5650Test extends WebDriverTestCase {
 		waitResponse();
 		dropUploadFile(jq("@dropupload"), Paths.get("src/main/webapp/test2/img/sun.jpg"));
 		waitResponse();
+		assertNoAnyError();
 		assertEquals("sun.jpg", getZKLog());
 	}
 }


### PR DESCRIPTION
This should be merged after https://github.com/zkoss/zats/pull/37 to use the latest version of zats-mimic-ext.
This should be merged alongside https://github.com/zkoss/zkcml/pull/1139.