### PR TITLE
ZK-5679: RichletMapping with "/" on Class does not work on StatelessR…

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -2,6 +2,7 @@ ZK 10.0.1
 * Features
 
 * Bugs
+  ZK-5679: RichletMapping with "/" on Class does not work on StatelessRichlet class
 
 * Upgrade Notes
 

--- a/zweb/src/main/java/org/zkoss/web/servlet/http/Https.java
+++ b/zweb/src/main/java/org/zkoss/web/servlet/http/Https.java
@@ -396,6 +396,9 @@ public class Https extends Servlets {
 		if (path == null) {
 			return null;
 		}
+		if ("/".equals(path)) {
+			return path;
+		}
 
 		List<String> parts = new ArrayList<>();
 		String[] segments = path.split("/");


### PR DESCRIPTION
…ichlet class

This PR should be merge alongside zkoss/zkcml#1151