### PR TITLE
ZK-5230: adding Barcodescanner twice causes javascript errors

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -13,6 +13,10 @@ ZK 10.2.0
   ZK-5914: vflex will fail if display:flex is set at the same time
   ZK-5915: DOMPurify before 3.2.4 has an incorrect template literal regular expression, sometimes leading to mutation cross-site scripting (mXSS)
   ZK-5458: zkplus DelegatingVariableResolver not longer works for the normal CDI case or for Quarkus ARC
+  ZK-5230: adding Barcodescanner twice causes javascript errors
+  ZK-5231: removing a barcodescanner immediately right after the browser renders it causes javascript error
+  ZK-5898: QR code scanning does not work in Barcodescanner
+  ZK-4337: barcodescanner can only instantiate reader once per page
 
 * Upgrade Notes
   + Remove the Fragment component from the zkmax.jar and use the new Client MVVM  (client-bind.jar) library instead.

--- a/zktest/build.gradle
+++ b/zktest/build.gradle
@@ -132,7 +132,7 @@ dependencies {
 	testImplementation 'org.eclipse.jetty:apache-jsp:10.0.11'
 	testImplementation 'org.junit.platform:junit-platform-launcher:1.9.0'
 	testImplementation 'xml-apis:xml-apis:1.4.01'
-	testImplementation 'org.zkoss.test:zk-webdriver:1.4.27.0.0'
+	testImplementation 'org.zkoss.test:zk-webdriver:1.4.27.0.2'
 
 	// For B96_ZK_4194Test to use a specific Chrome driver version (this will change to match latest chrome)
 	testImplementation 'org.seleniumhq.selenium:selenium-devtools-v130:4.26.0'

--- a/zktest/src/main/webapp/test2/B102-ZK-4337.zul
+++ b/zktest/src/main/webapp/test2/B102-ZK-4337.zul
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+B102-ZK-4337.zul
+
+	Purpose:
+		
+	Description:
+		
+	History:
+		Wed Mar 26 10:10:12 CST 2025, Created by jameschu
+
+Copyright (C) 2025 Potix Corporation. All Rights Reserved.
+
+-->
+<zk>
+	<label>
+		Shall see both barcode scanners work.
+	</label>
+	<barcodescanner id="bcs2" type="qr,code128" continuous="true" interval="1000" height="100px" onDetect='lb2.setValue(event.getResult());Clients.log("bcs2 "+event.getType() + " " + event.getResult())'/>
+	<barcodescanner id="bcs" type="qr,code128" continuous="true" interval="1000" height="100px" onDetect='lb1.setValue(event.getResult());Clients.log("bcs1 "+event.getType() + " " + event.getResult())'/>
+	<label id="lb1"/>
+	<label id="lb2"/>
+</zk>

--- a/zktest/src/main/webapp/test2/B102-ZK-5230-1.zul
+++ b/zktest/src/main/webapp/test2/B102-ZK-5230-1.zul
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+B102-ZK-5230-1.zul
+
+	Purpose:
+
+	Description:
+
+	History:
+		Tue Jan 14 11:31:22 CST 2025, Created by jameschu
+
+Copyright (C) 2025 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+	<window id="win" apply="org.zkoss.zktest.test2.B102_ZK_5230Composer">
+		<label multiline="true">
+			1. run in ios mobile (ios ver 18+)
+			2. Click "detach" then "attach"
+			3. the barcode scanner shall work
+		</label>
+		<button onClick="bs.setEnable(false)" label="disable" />
+		<button onClick="bs.setEnable(true)" label="enable" />
+		<button id="deBtn" label="detach" />
+		<button id="atBtn" label="attach" />
+		<button id="addBtn" label="add new" />
+		<barcodescanner id="bs" width="300px" height="300px" onDetect='Clients.log(event.getType() + " " + event.getResult())'/>
+	</window>
+</zk>

--- a/zktest/src/main/webapp/test2/B102-ZK-5230.zul
+++ b/zktest/src/main/webapp/test2/B102-ZK-5230.zul
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+B102-ZK-5230.zul
+
+	Purpose:
+
+	Description:
+
+	History:
+		Tue Mar 25 14:35:41 CST 2025, Created by jameschu
+
+Copyright (C) 2025 Potix Corporation. All Rights Reserved.
+-->
+
+<zk>
+	<vlayout id="container">
+		<label multiline="true"><![CDATA[
+			1. click "add" button, wait the camera to start showing the video around 3 seconds
+			2. Click "remove" button
+			3. click "add" button
+			4. no js error
+		]]></label>
+		<button label="remove" onClick="removeScanner()"/>
+		<button label="add" onClick="addScanner()"/>
+	</vlayout>
+	<zscript><![CDATA[
+    import org.zkoss.zkmax.zul.Barcodescanner;
+
+    Barcodescanner scanner;
+
+    public void addScanner() {
+        scanner = new Barcodescanner();
+        scanner.setType("CODE128");
+        scanner.setContinuous(true);
+        scanner.setInterval(1000);
+        scanner.setHeight("100px");
+        container.appendChild(scanner);
+    }
+
+    public void removeScanner(){
+        container.removeChild(scanner);
+    }
+    ]]></zscript>
+</zk>

--- a/zktest/src/main/webapp/test2/B102-ZK-5231.zul
+++ b/zktest/src/main/webapp/test2/B102-ZK-5231.zul
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+B102-ZK-5231.zul
+
+	Purpose:
+
+	Description:
+
+	History:
+		Tue Mar 25 14:35:41 CST 2025, Created by jameschu
+
+Copyright (C) 2025 Potix Corporation. All Rights Reserved.
+-->
+
+<zk>
+	<vlayout>
+		scan result:
+		<label id="lb1"/>
+		<barcodescanner id="bcs" type="qr,code128" continuous="true" interval="1000" height="100px"
+						onDetect='lb1.setValue(event.getResult());Clients.log("bcs1 "+event.getType() + " " + event.getResult())'/>
+		<label multiline="true"><![CDATA[
+		1. click the button within 2 seconds after the browser renders this page
+		2. no exception
+		]]></label>
+		<button label="remove" onClick='bcs.getParent().removeChild(bcs)'/>
+	</vlayout>
+</zk>

--- a/zktest/src/main/webapp/test2/B102-ZK-5898.zul
+++ b/zktest/src/main/webapp/test2/B102-ZK-5898.zul
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+B102-ZK-5898.zul
+
+	Purpose:
+		
+	Description:
+		
+	History:
+		Tue Mar 25 14:35:41 CST 2025, Created by jameschu
+
+Copyright (C) 2024 Potix Corporation. All Rights Reserved.
+
+-->
+<zk>
+	<window border="normal" title="hello">
+		<label>This should be able to scan qr-code</label>
+		<barcodescanner type="qr,code128" continuous="true" interval="500" height="100px" onDetect="result.value = event.result"/>
+		<separator/>
+		QR code scan result: <label id="result"/>
+	</window>
+</zk>

--- a/zktest/src/main/webapp/test2/B86-ZK-4095.zul
+++ b/zktest/src/main/webapp/test2/B86-ZK-4095.zul
@@ -21,7 +21,7 @@ Copyright (C) 2018 Potix Corporation. All Rights Reserved.
     </label>
     <zscript><![CDATA[
     void onDetect(org.zkoss.zkmax.zul.event.DetectEvent e) {
-        if ("qr".equalsIgnoreCase(e.getType()))
+        if (e.getType().contains("QR"))
             resultQR.setValue(e.getResult());
         else
             resultEan.setValue(e.getResult());

--- a/zktest/src/main/webapp/test2/config.properties
+++ b/zktest/src/main/webapp/test2/config.properties
@@ -3158,6 +3158,11 @@ B90-ZK-4431.zul=A,E,Multislider
 ##zats##B102-ZK-5487.zul=A,E,Listheader,Column,Flex,Percentage
 ##zats##B102-ZK-5914.zul=A,E,CSS,Display,Flex
 ##zats##B102-ZK-5458.zul=A,E,CDI,zkplus,Bean,Injection
+##manually##B102-ZK-5898.zul=A,E,Barcodescanner,QR
+##manually##B102-ZK-5231.zul=A,E,Barcodescanner
+##manually##B102-ZK-5230-1.zul=A,E,Barcodescanner
+##manually##B102-ZK-5230.zul=A,E,Barcodescanner
+##manually##B102-ZK-4337.zul=A,E,Barcodescanner
 
 ##
 # Features - 3.0.x version


### PR DESCRIPTION
ZK-5231: removing a barcodescanner immediately right after the browser renders it causes javascript error
ZK-5898: QR code scanning does not work in Barcodescanner

This PR should be merge alongside zkoss/zkcml#1212