### PR TITLE
ZK-5396: Checkbox can show its focused state

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -13,6 +13,20 @@ ZK 10.2.0
   ZK-5888: can focus on a checkbox in a tree column with a keyboard
   ZK-4966: support a way to avoid loading third-party javascript library
   ZK-5597: vertical stepbar
+  ZK-5396: Checkbox can show its focused state
+  ZK-5867: Radio can show its focused state
+  ZK-5395: Listbox can show its focused state
+  ZK-5486: za11y: Support showing when a Listbox receives focus via keyboard
+  ZK-5925: Listheader can show its focused state
+  ZK-5497: Tree can show its focused state
+  ZK-5499: Treecol can show its focused state
+  ZK-5926: Column can show its focused state
+  ZK-5930: Cell can show its focused state
+  ZK-5518: Groupbox can show its focused state
+  ZK-5521: Nav can show its focused state
+  ZK-5868: Paging can show its focused state
+  ZK-5932: Listheader's checkbox can show its focused state
+  ZK-5933: Treecol's checkbox can show its focused state
 
 * Bugs
   ZK-5728: ZK-5364 causes external radio to no longer be selected / checked
@@ -51,6 +65,8 @@ ZK 10.2.0
   ZK-5222: websocket fails and resend AU request get a 467 response
   ZK-5693: message key NO_POSITIVE_NEGATIVE_ZERO has wrong values in many locales
   ZK-5695: unable to use EL in a native script
+  ZK-5648: listbox focused item and selected item has the same background color
+  ZK-5882: tree focused item and selected item has the same background color
 
 * Upgrade Notes
   + Remove the Fragment component from the zkmax.jar and use the new Client MVVM  (client-bind.jar) library instead.

--- a/zktest/src/main/webapp/test2/B102-ZK-5648.zul
+++ b/zktest/src/main/webapp/test2/B102-ZK-5648.zul
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+B102-ZK-5648.zul
+
+        Purpose:
+
+        Description:
+
+        History:
+                Wed Apr 23 15:07:06 CST 2025, Created by jamson
+
+Copyright (C) 2025 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+    <label multiline="true">
+        1. press TAB to focus on the listbox
+        2. press and hold COMMAND key (COMMAND for mac, CTRL for windows), and press ARROW_DOWN, and then release COMMAND key, to move focus
+        3. check whether the specific row you focused has the focus border style
+    </label>
+    <listbox>
+        <listhead>
+            <listheader label="1"/>
+            <listheader label="2"/>
+            <listheader label="3"/>
+        </listhead>
+        <listitem>
+            <listcell label="1" />
+            <listcell label="2" />
+            <listcell label="3" />
+        </listitem>
+        <listitem>
+            <listcell label="1" />
+            <listcell label="2" />
+            <listcell label="3" />
+        </listitem>
+        <listitem>
+            <listcell label="1" />
+            <listcell label="2" />
+            <listcell label="3" />
+        </listitem>
+    </listbox>
+</zk>

--- a/zktest/src/main/webapp/test2/B102-ZK-5882.zul
+++ b/zktest/src/main/webapp/test2/B102-ZK-5882.zul
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+B102-ZK-5882.zul
+
+        Purpose:
+
+        Description:
+
+        History:
+                Thu Apr 24 14:23:29 CST 2025, Created by jamson
+
+Copyright (C) 2025 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+    <label multiline="true">
+        1. press TAB to focus on the tree
+        2. press and hold COMMAND key (COMMAND for mac, CTRL for windows), and press ARROW_DOWN, and then release COMMAND key, to move focus
+        3. check whether the specific row you focused has the focus border style
+    </label>
+    <tree>
+        <treecols>
+            <treecol label="1"/>
+            <treecol label="2"/>
+            <treecol label="3"/>
+        </treecols>
+        <treechildren>
+            <treeitem>
+                <treerow>
+                    <treecell label="1" />
+                    <treecell label="2" />
+                    <treecell label="3" />
+                </treerow>
+            </treeitem>
+            <treeitem>
+                <treerow>
+                    <treecell label="1" />
+                    <treecell label="2" />
+                    <treecell label="3" />
+                </treerow>
+            </treeitem>
+            <treeitem>
+                <treerow>
+                    <treecell label="1" />
+                    <treecell label="2" />
+                    <treecell label="3" />
+                </treerow>
+            </treeitem>
+        </treechildren>
+    </tree>
+</zk>

--- a/zktest/src/main/webapp/test2/F102-ZK-5395.zul
+++ b/zktest/src/main/webapp/test2/F102-ZK-5395.zul
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+F102-ZK-5395.zul
+
+        Purpose:
+
+        Description:
+
+        History:
+                Thu Apr 10 10:57:01 CST 2025, Created by jamson
+
+Copyright (C) 2025 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+    <label multiline="true">
+        press TAB to focus on the listbox, you should see listbox has the border highlight
+        (Note: this issue is duplicated by ZK-5486)
+    </label>
+    <listbox>
+        <listhead>
+            <listheader label="1"  />
+            <listheader label="2" />
+        </listhead>
+        <listitem>
+            <listcell label="1" />
+            <listcell label="2" />
+        </listitem>
+    </listbox>
+</zk>

--- a/zktest/src/main/webapp/test2/F102-ZK-5396.zul
+++ b/zktest/src/main/webapp/test2/F102-ZK-5396.zul
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+F102-ZK-5396.zul
+
+        Purpose:
+
+        Description:
+
+        History:
+                Tue Apr 08 14:56:02 CST 2025, Created by jamson
+
+Copyright (C) 2025 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+    <label multiline="true">
+        press TAB to focus on each checkbox, all of them should have the border highlight
+    </label>
+    <checkbox id="cbdefault" label='checkbox mold="default"'/><separator/>
+    <checkbox mold='tristate' id="cbtristate" label='checkbox mold="tristate"'/><separator/>
+</zk>

--- a/zktest/src/main/webapp/test2/F102-ZK-5497.zul
+++ b/zktest/src/main/webapp/test2/F102-ZK-5497.zul
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+F102-ZK-5497.zul
+
+        Purpose:
+
+        Description:
+
+        History:
+                Thu Apr 10 12:18:25 CST 2025, Created by jamson
+
+Copyright (C) 2025 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+    <label multiline="true">
+        press TAB to focus on the tree, you should see tree has the border highlight
+    </label>
+    <tree checkmark="true" multiple="true">
+        <treecols>
+            <treecol label="1"/>
+            <treecol label="2"/>
+        </treecols>
+        <treechildren>
+            <treeitem>
+                <treerow>
+                    <treecell label="1"/>
+                    <treecell label="2"/>
+                </treerow>
+            </treeitem>
+            <treeitem>
+                <treerow>
+                    <treecell label="1"/>
+                    <treecell label="2"/>
+                </treerow>
+            </treeitem>
+        </treechildren>
+    </tree>
+</zk>

--- a/zktest/src/main/webapp/test2/F102-ZK-5499.zul
+++ b/zktest/src/main/webapp/test2/F102-ZK-5499.zul
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+F102-ZK-5499.zul
+
+        Purpose:
+
+        Description:
+
+        History:
+                Thu Apr 10 12:49:00 CST 2025, Created by jamson
+
+Copyright (C) 2025 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+    <label multiline="true">
+        1. press TAB to focus on the tree
+        2. and press DOWN ARROW and then UP ARROW to focus on treecol
+        3. you should see treecol has the border highlight
+    </label>
+    <tree>
+        <treecols>
+            <treecol label="1"/>
+            <treecol label="2"/>
+        </treecols>
+        <treechildren>
+            <treeitem>
+                <treerow>
+                    <treecell label="1"/>
+                    <treecell label="2"/>
+                </treerow>
+            </treeitem>
+            <treeitem>
+                <treerow>
+                    <treecell label="1"/>
+                    <treecell label="2"/>
+                </treerow>
+            </treeitem>
+        </treechildren>
+    </tree>
+</zk>

--- a/zktest/src/main/webapp/test2/F102-ZK-5518.zul
+++ b/zktest/src/main/webapp/test2/F102-ZK-5518.zul
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+F102-ZK-5518.zul
+
+        Purpose:
+
+        Description:
+
+        History:
+                Thu Apr 10 12:38:06 CST 2025, Created by jamson
+
+Copyright (C) 2025 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+    <label multiline="true">
+        1. press TAB to focus on the first groupbox, you should see the first groupbox's toggle icon has the border highlight
+        2. press TAB 2 times to focus on the second groupbox, you should see the second groupbox has the border highlight
+    </label>
+    <groupbox width="250px">
+        <caption iconSclass="z-icon-angle-down"/>
+        <textbox/>
+    </groupbox>
+    <groupbox width="250px" mold="3d">
+        <caption iconSclass="z-icon-angle-down"/>
+        <textbox/>
+    </groupbox>
+</zk>

--- a/zktest/src/main/webapp/test2/F102-ZK-5521.zul
+++ b/zktest/src/main/webapp/test2/F102-ZK-5521.zul
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+F102-ZK-5521.zul
+
+        Purpose:
+
+        Description:
+
+        History:
+                Thu Apr 10 16:15:06 CST 2025, Created by jamson
+
+Copyright (C) 2025 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+    <label multiline="true">
+        1. press TAB to focus on the first navbar's first navitem, you should see the first navitem has the border highlight
+        2. press ARROW_DOWN to focus on the first nav, you should see the nav has the border highlight
+        3. press ARROW_RIGHT to open the nav (it'll focus on the nested navitem meanwhile), and you should see the nested navitem has the border highlight
+        4. press TAB to focus on the second navbar's first navitem, you should see the first navitem has the border highlight
+        5. press ARROW_RIGHT to focus on the first nav, you should see the nav has the border highlight
+        6. press ARROW_DOWN to open the nav (it'll focus on the nested navitem meanwhile), and you should see the nested navitem has the border highlight
+    </label>
+    <navbar orient="vertical" width="200px">
+        <navitem label="1" iconSclass="z-icon-home"/>
+        <nav label="2" iconSclass="z-icon-th-list">
+            <navitem label="2-1" />
+            <navitem label="2-2" />
+        </nav>
+    </navbar>
+    <navbar orient="horizontal">
+        <navitem label="1" iconSclass="z-icon-home"/>
+        <nav label="2" iconSclass="z-icon-th-list">
+            <navitem label="2-1" />
+            <navitem label="2-2" />
+        </nav>
+    </navbar>
+</zk>

--- a/zktest/src/main/webapp/test2/F102-ZK-5867.zul
+++ b/zktest/src/main/webapp/test2/F102-ZK-5867.zul
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+F102-ZK-5867.zul
+
+        Purpose:
+
+        Description:
+
+        History:
+                Thu Apr 17 17:41:01 CST 2025, Created by jamson
+
+Copyright (C) 2025 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+    <label multiline="true">
+        press TAB to focus on each radio (or RIGHT ARROW if radiogroup), all of them should have the border highlight
+    </label>
+    <radio id="rd" label="radio"/><separator/>
+    <radiogroup id='rg1' style='border:1px solid red'>
+        <radio id="radiogrouprd1" label='1'/>
+        <radio id="radiogrouprd2" label='2'/>
+    </radiogroup> radiogroup
+
+    <radiogroup id='rg2'/>
+    <grid width="400px">
+        <rows>
+            <row>
+                <radio id="row1rd1" label="radio1"/>
+                <radio id="row1rd2" label="radio2"/>
+            </row>
+            <row>
+                <radio id="row2radiogrouprd1" label="radiogroup2" radiogroup="rg2"/>
+                <radio id="row2radiogrouprd2" label="radiogroup2" radiogroup="rg2"/>
+            </row>
+            <row>
+                <checkbox id="row3cb1" label="checkbox1"/>
+                <checkbox id="row3cb2" label="checkbox2"/>
+            </row>
+        </rows>
+    </grid>
+</zk>

--- a/zktest/src/main/webapp/test2/F102-ZK-5868.zul
+++ b/zktest/src/main/webapp/test2/F102-ZK-5868.zul
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+F102-ZK-5868.zul
+
+        Purpose:
+
+        Description:
+
+        History:
+                Thu Apr 17 17:55:21 CST 2025, Created by jamson
+
+Copyright (C) 2025 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+    <label multiline="true">
+        1. press TAB 1 time, you should see the first-page-icon have the border highlight
+        2. press TAB again, you should see the previous-page-icon have the border highlight
+        3. press TAB 2 times, you should see the next-page-icon have the border highlight
+        3. press TAB again, you should see the last-page-icon have the border highlight
+    </label>
+    <paging totalSize="3" pageSize="1" activePage="1"/>
+</zk>

--- a/zktest/src/main/webapp/test2/F102-ZK-5925.zul
+++ b/zktest/src/main/webapp/test2/F102-ZK-5925.zul
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+F102-ZK-5925.zul
+
+        Purpose:
+
+        Description:
+
+        History:
+                Thu Apr 17 16:00:22 CST 2025, Created by jamson
+
+Copyright (C) 2025 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+    <label multiline="true">
+        1. press TAB, ARROW_DOWN, ARROW_UP to focus on the listheader
+        2. you should see listheader has the border highlight
+    </label>
+    <listbox>
+        <listhead>
+            <listheader label="1"  />
+            <listheader label="2" />
+        </listhead>
+        <listitem>
+            <listcell label="1" />
+            <listcell label="2" />
+        </listitem>
+    </listbox>
+</zk>

--- a/zktest/src/main/webapp/test2/F102-ZK-5926.zul
+++ b/zktest/src/main/webapp/test2/F102-ZK-5926.zul
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+F102-ZK-5926.zul
+
+        Purpose:
+
+        Description:
+
+        History:
+                Thu Apr 17 16:00:46 CST 2025, Created by jamson
+
+Copyright (C) 2025 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+    <label multiline="true">
+        1. press TAB, ARROW_UP to focus on the column
+        2. you should see column has the border highlight
+    </label>
+    <grid>
+        <columns>
+            <column>1</column>
+            <column>2</column>
+        </columns>
+        <rows>
+            <row>
+                <cell>1</cell>
+                <cell>2</cell>
+            </row>
+            <row>
+                <cell>1</cell>
+                <cell>2</cell>
+            </row>
+        </rows>
+    </grid>
+</zk>

--- a/zktest/src/main/webapp/test2/F102-ZK-5930.zul
+++ b/zktest/src/main/webapp/test2/F102-ZK-5930.zul
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+F102-ZK-5930.zul
+
+        Purpose:
+
+        Description:
+
+        History:
+                Thu Apr 24 15:15:30 CST 2025, Created by jamson
+
+Copyright (C) 2025 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+    <label multiline="true">
+        1. press TAB to focus on the top-left-cell
+        2. you should see the cell has the border highlight
+        3. press ARROW keys to check the focus border highlight is apply on each cell
+    </label>
+    <grid>
+        <columns>
+            <column>1</column>
+            <column>2</column>
+        </columns>
+        <rows>
+            <row>
+                <cell>1</cell>
+                <cell>2</cell>
+            </row>
+            <row>
+                <cell>1</cell>
+                <cell>2</cell>
+            </row>
+        </rows>
+    </grid>
+</zk>

--- a/zktest/src/main/webapp/test2/F102-ZK-5932.zul
+++ b/zktest/src/main/webapp/test2/F102-ZK-5932.zul
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+F102-ZK-5932.zul
+
+        Purpose:
+
+        Description:
+
+        History:
+                Mon Apr 28 11:20:44 CST 2025, Created by jamson
+
+Copyright (C) 2025 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+    <label multiline="true">
+        1. press TAB to focus on Listbox, and press ARROW_DOWN, and press ARROW_UP to focus on listheader's checkbox
+        2. you should see listheader's checkbox has the border highlight
+    </label>
+    <listbox multiple="true" checkmark="true">
+        <listhead>
+            <listheader sort="auto">1</listheader>
+            <listheader sort="auto">2</listheader>
+        </listhead>
+        <listitem>
+            <listcell>1</listcell>
+            <listcell>1</listcell>
+        </listitem>
+        <listitem>
+            <listcell>2</listcell>
+            <listcell>2</listcell>
+        </listitem>
+    </listbox>
+</zk>

--- a/zktest/src/main/webapp/test2/F102-ZK-5933.zul
+++ b/zktest/src/main/webapp/test2/F102-ZK-5933.zul
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+F102-ZK-5933.zul
+
+        Purpose:
+
+        Description:
+
+        History:
+                Mon Apr 28 11:20:55 CST 2025, Created by jamson
+
+Copyright (C) 2025 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+    <label multiline="true">
+        1. press TAB to focus on Tree, and press ARROW_UP to focus on treecol's checkbox
+        2. you should see treecol's checkbox has the border highlight
+    </label>
+    <tree multiple="true" checkmark="true">
+        <treecols>
+            <treecol sort="auto">1</treecol>
+            <treecol sort="auto">2</treecol>
+        </treecols>
+        <treechildren>
+            <treeitem>
+                <treerow>
+                    <treecell>1</treecell>
+                    <treecell>1</treecell>
+                </treerow>
+            </treeitem>
+            <treeitem>
+                <treerow>
+                    <treecell>2</treecell>
+                    <treecell>2</treecell>
+                </treerow>
+            </treeitem>
+        </treechildren>
+    </tree>
+</zk>

--- a/zktest/src/main/webapp/test2/config.properties
+++ b/zktest/src/main/webapp/test2/config.properties
@@ -3182,6 +3182,8 @@ B90-ZK-4431.zul=A,E,Multislider
 ##manually##B102-ZK-5664.zul=A,E,filename,encoding,locale,request,filedownload
 ##manually##B102-ZK-5222.zul=A,E,Websocket,tomcat,ajax
 ##zats##B102-ZK-5695.zul=A,E,NativeInfo,TextInfo,EL expression
+##zats##B102-ZK-5648.zul=A,E,Listbox,Listitem,focus,selected
+##zats##B102-ZK-5882.zul=A,E,Tree,Treerow,focus,selected
 
 ##
 # Features - 3.0.x version
@@ -3822,6 +3824,19 @@ F86-ZK-4235.zul=A,E,datefmt,library-property
 ##zats##F102-ZK-5474.zul=A,E,NumberInputElement,NumberInputWidget,constraint,minimum,maximum
 ##zats##F102-ZK-5888.zul=A,E,Treecol,Checkbox,focus
 ##zats##F102-ZK-5597.zul=A,E,Stepbar,vertical,orient
+##zats##F102-ZK-5396.zul=A,E,Checkbox,focus,UI
+##zats##F102-ZK-5867.zul=A,E,Radio,focus,UI
+##zats##F102-ZK-5395.zul=A,E,Listbox,focus,UI
+##zats##F102-ZK-5925.zul=A,E,Listheader,focus,UI
+##zats##F102-ZK-5497.zul=A,E,Tree,focus,UI
+##zats##F102-ZK-5499.zul=A,E,Treecol,focus,UI
+##zats##F102-ZK-5926.zul=A,E,Column,focus,UI
+##zats##F102-ZK-5930.zul=A,E,Cell,focus,UI
+##zats##F102-ZK-5518.zul=A,E,Groupbox,Caption,focus,UI
+##zats##F102-ZK-5521.zul=A,E,Navbar,Nav,Navitem,focus,UI
+##zats##F102-ZK-5868.zul=A,E,Paging,focus,UI
+##zats##F102-ZK-5932.zul=A,E,Listheader,Checkbox,focus,UI
+##zats##F102-ZK-5933.zul=A,E,Treecol,Checkbox,focus,UI
 
 # Complex Test Case
 #

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B102_ZK_5505Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B102_ZK_5505Test.java
@@ -12,11 +12,13 @@ Copyright (C) 2025 Potix Corporation. All Rights Reserved.
 package org.zkoss.zktest.zats.test2;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.Keys;
 
 import org.zkoss.test.webdriver.WebDriverTestCase;
 
+@Tag("WcagTestOnly")
 public class B102_ZK_5505Test extends WebDriverTestCase {
     
     @Test

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B102_ZK_5506Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B102_ZK_5506Test.java
@@ -12,11 +12,13 @@ Copyright (C) 2025 Potix Corporation. All Rights Reserved.
 package org.zkoss.zktest.zats.test2;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.Keys;
 
 import org.zkoss.test.webdriver.WebDriverTestCase;
 
+@Tag("WcagTestOnly")
 public class B102_ZK_5506Test extends WebDriverTestCase {
 
     @Test

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B102_ZK_5648Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B102_ZK_5648Test.java
@@ -1,0 +1,90 @@
+/* B102_ZK_5648Test.java
+
+        Purpose:
+                
+        Description:
+                
+        History:
+                Wed Apr 23 15:06:12 CST 2025, Created by jamson
+
+Copyright (C) 2025 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Keys;
+
+import org.zkoss.test.webdriver.WebDriverTestCase;
+import org.zkoss.test.webdriver.ztl.JQuery;
+
+public class B102_ZK_5648Test extends WebDriverTestCase {
+    
+    private static String TOP = "0px 2px 0px 0px",
+            RIGHT = "-2px 0px 0px 0px",
+            BOTTOM = "0px -2px 0px 0px",
+            LEFT = "2px 0px 0px 0px";
+    
+    protected String CELL_CONTAINER = "@listitem",
+        CELL = "@listcell";
+    
+    @Test
+    public void test() {
+        connect();
+        getActions().sendKeys(Keys.TAB).perform();
+        moveFocusDown();
+        assertFocusOnNthItem(0);
+        moveFocusDown();
+        assertFocusOnNthItem(1);
+        moveFocusDown();
+        assertFocusOnNthItem(2);
+    }
+    
+    private void moveFocusDown() {
+        Keys ctrl = isMac() ? Keys.META : Keys.CONTROL;
+        getActions().keyDown(ctrl).sendKeys(Keys.ARROW_DOWN).keyUp(ctrl).perform();
+    }
+
+    private void assertFocusOnNthItem(int index) {
+        int m = jq(CELL_CONTAINER).length();
+        Assertions.assertEquals(3, m);
+        for (int i = 0; i < m; ++i) {
+            JQuery $item = jq(CELL_CONTAINER).eq(i);
+            int n = $item.find(CELL).length();
+            Assertions.assertEquals(3, n);
+            if (i == index) {
+                for (int j = 0; j < n; ++j) {
+                    JQuery $cell = $item.find(CELL).eq(j);
+                    boolean leftExists = j == 0,
+                            rightExists = j == n - 1;
+                    assertBorderFocusExist($cell, new boolean[] {true, rightExists, true, leftExists});
+                }
+            } else {
+                for (int j = 0; j < n; ++j) {
+                    JQuery $cell = $item.find(CELL).eq(j);
+                    assertBorderFocusExist($cell, new boolean[] {false, false, false, false});
+                }
+            }
+        }
+    }
+
+    // borderExistsArray means whether {top, right, bottom, left} border focus style exists 
+    private void assertBorderFocusExist(JQuery $cell, boolean[] borderExistsArray) {
+        String[] parsed = Arrays.stream($cell.css("box-shadow")
+                .replace("inset", "")
+                .replaceAll("rgb\\([^)]*\\)", "")
+                .split(","))
+                .map(String::trim)
+                .toArray(String[]::new);
+        boolean[] actual = new boolean[borderExistsArray.length];
+        for (String p : parsed) {
+            if (TOP.equals(p)) actual[0] = true;
+            else if (RIGHT.equals(p)) actual[1] = true;
+            else if (BOTTOM.equals(p)) actual[2] = true;
+            else if (LEFT.equals(p)) actual[3] = true;
+        }
+        Assertions.assertEquals(Arrays.toString(borderExistsArray), Arrays.toString(actual));
+    }
+}

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B102_ZK_5882Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B102_ZK_5882Test.java
@@ -1,0 +1,19 @@
+/* B102_ZK_5882Test.java
+
+        Purpose:
+                
+        Description:
+                
+        History:
+                Thu Apr 24 14:27:51 CST 2025, Created by jamson
+
+Copyright (C) 2025 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+public class B102_ZK_5882Test extends B102_ZK_5648Test {
+    private B102_ZK_5882Test() {
+        super.CELL_CONTAINER = "@treerow";
+        super.CELL = "@treecell";
+    }
+}

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/F102_ZK_5395Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/F102_ZK_5395Test.java
@@ -1,0 +1,33 @@
+/* F102_ZK_5395Test.java
+
+        Purpose:
+
+        Description:
+
+        History:
+                Thu Apr 10 11:02:54 CST 2025, Created by jamson
+
+Copyright (C) 2025 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Keys;
+
+import org.zkoss.test.webdriver.WebDriverTestCase;
+import org.zkoss.test.webdriver.ztl.JQuery;
+
+@Tag("WcagTestOnly")
+public class F102_ZK_5395Test extends WebDriverTestCase {
+
+    @Test
+    public void test() {
+        connect();
+        JQuery listbox = jq("@listbox");
+        Assertions.assertEquals("none", listbox.css("box-shadow"));
+        getActions().sendKeys(Keys.TAB).perform();
+        Assertions.assertNotEquals("none", listbox.css("box-shadow"));
+    }
+}

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/F102_ZK_5396Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/F102_ZK_5396Test.java
@@ -1,0 +1,35 @@
+/* F102_ZK_5396Test.java
+
+        Purpose:
+
+        Description:
+
+        History:
+                Wed Apr 09 18:16:30 CST 2025, Created by jamson
+
+Copyright (C) 2025 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Keys;
+
+import org.zkoss.test.webdriver.WebDriverTestCase;
+import org.zkoss.test.webdriver.ztl.JQuery;
+
+public class F102_ZK_5396Test extends WebDriverTestCase {
+
+    @Test
+    public void test() {
+        connect();
+        JQuery cbDefault = jq("$cbdefault input"),
+                cbTristate = jq("$cbtristate input");
+        Assertions.assertEquals("none", cbDefault.css("box-shadow"));
+        getActions().sendKeys(Keys.TAB).perform();
+        Assertions.assertNotEquals("none", cbDefault.css("box-shadow"));
+        Assertions.assertEquals("none", cbTristate.css("box-shadow"));
+        getActions().sendKeys(Keys.TAB).perform();
+        Assertions.assertNotEquals("none", cbTristate.css("box-shadow"));
+    }
+}

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/F102_ZK_5497Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/F102_ZK_5497Test.java
@@ -1,0 +1,33 @@
+/* F102_ZK_5497Test.java
+
+        Purpose:
+
+        Description:
+
+        History:
+                Thu Apr 10 12:22:41 CST 2025, Created by jamson
+
+Copyright (C) 2025 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Keys;
+
+import org.zkoss.test.webdriver.WebDriverTestCase;
+import org.zkoss.test.webdriver.ztl.JQuery;
+
+@Tag("WcagTestOnly")
+public class F102_ZK_5497Test extends WebDriverTestCase {
+
+    @Test
+    public void test() {
+        connect();
+        JQuery tree = jq("@tree");
+        Assertions.assertEquals("none", tree.css("box-shadow"));
+        getActions().sendKeys(Keys.TAB).perform();
+        Assertions.assertNotEquals("none", tree.css("box-shadow"));
+    }
+}

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/F102_ZK_5499Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/F102_ZK_5499Test.java
@@ -1,0 +1,33 @@
+/* F102_ZK_5499Test.java
+
+        Purpose:
+                
+        Description:
+                
+        History:
+                Thu Apr 10 12:59:34 CST 2025, Created by jamson
+
+Copyright (C) 2025 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Keys;
+
+import org.zkoss.test.webdriver.WebDriverTestCase;
+import org.zkoss.test.webdriver.ztl.JQuery;
+
+@Tag("WcagTestOnly")
+public class F102_ZK_5499Test extends WebDriverTestCase {
+
+    @Test
+    public void test() {
+        connect();
+        JQuery treecol = jq("@treecol");
+        Assertions.assertEquals("none", treecol.css("box-shadow"));
+        getActions().sendKeys(Keys.TAB, Keys.ARROW_DOWN, Keys.ARROW_UP).perform();
+        Assertions.assertNotEquals("none", treecol.css("box-shadow"));
+    }
+}

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/F102_ZK_5518Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/F102_ZK_5518Test.java
@@ -1,0 +1,37 @@
+/* F102_ZK_5518Test.java
+
+        Purpose:
+                
+        Description:
+                
+        History:
+                Fri Apr 11 22:12:40 CST 2025, Created by jamson
+
+Copyright (C) 2025 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Keys;
+
+import org.zkoss.test.webdriver.WebDriverTestCase;
+import org.zkoss.test.webdriver.ztl.JQuery;
+
+@Tag("WcagTestOnly")
+public class F102_ZK_5518Test extends WebDriverTestCase {
+
+    @Test
+    public void test() {
+        connect();
+        JQuery groupbox1 = jq("@groupbox:eq(0) .z-caption"),
+            groupbox2 = jq("@groupbox:eq(1) .z-caption-content");
+        Assertions.assertEquals("none", groupbox1.css("box-shadow"));
+        getActions().sendKeys(Keys.TAB).perform();
+        Assertions.assertNotEquals("none", groupbox1.css("box-shadow"));
+        Assertions.assertEquals("none", groupbox2.css("box-shadow"));
+        getActions().sendKeys(Keys.TAB, Keys.TAB).perform();
+        Assertions.assertNotEquals("none", groupbox2.css("box-shadow"));
+    }
+}

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/F102_ZK_5521Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/F102_ZK_5521Test.java
@@ -1,0 +1,66 @@
+/* F102_ZK_5521Test.java
+
+        Purpose:
+                
+        Description:
+                
+        History:
+                Thu Apr 10 16:33:27 CST 2025, Created by jamson
+
+Copyright (C) 2025 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Keys;
+
+import org.zkoss.test.webdriver.WebDriverTestCase;
+import org.zkoss.test.webdriver.ztl.JQuery;
+
+@Tag("WcagTestOnly")
+public class F102_ZK_5521Test extends WebDriverTestCase {
+
+    @Test
+    public void test() {
+        connect();
+        JQuery navitem = jq(".z-navitem-content"),
+                nav = jq(".z-nav-content"),
+                navitemInner1 = jq(".z-navitem-content:eq(1)"),
+                navitemInner2 = jq(".z-navitem-content:eq(2)");
+        
+        Assertions.assertEquals("none", navitem.css("box-shadow"));
+        getActions().sendKeys(Keys.TAB).perform();
+        Assertions.assertNotEquals("none", navitem.css("box-shadow"));
+        Assertions.assertEquals("none", nav.css("box-shadow"));
+        getActions().sendKeys(Keys.ARROW_DOWN).perform();
+        Assertions.assertNotEquals("none", nav.css("box-shadow"));
+        Assertions.assertEquals("none", navitemInner1.css("box-shadow"));
+        getActions().sendKeys(Keys.ARROW_RIGHT).perform();
+        Assertions.assertNotEquals("none", navitemInner1.css("box-shadow"));
+        Assertions.assertEquals("none", navitemInner2.css("box-shadow"));
+        getActions().sendKeys(Keys.ARROW_DOWN).perform();
+        Assertions.assertEquals("none", navitemInner1.css("box-shadow"));
+        Assertions.assertNotEquals("none", navitemInner2.css("box-shadow"));
+
+        navitem = jq(".z-navitem-content:eq(3)");
+        nav = jq(".z-nav-content:eq(1)");
+        navitemInner1 = jq(".z-navitem-content:eq(4)");
+        navitemInner2 = jq(".z-navitem-content:eq(5)");
+
+        Assertions.assertEquals("none", navitem.css("box-shadow"));
+        getActions().sendKeys(Keys.TAB).perform();
+        Assertions.assertNotEquals("none", navitem.css("box-shadow"));
+        Assertions.assertEquals("none", nav.css("box-shadow"));
+        getActions().sendKeys(Keys.ARROW_RIGHT).perform();
+        Assertions.assertNotEquals("none", nav.css("box-shadow"));
+        Assertions.assertEquals("none", navitemInner1.css("box-shadow"));
+        getActions().sendKeys(Keys.ARROW_DOWN).perform();
+        Assertions.assertNotEquals("none", navitemInner1.css("box-shadow"));
+        Assertions.assertEquals("none", navitemInner2.css("box-shadow"));
+        getActions().sendKeys(Keys.ARROW_RIGHT).perform();
+        Assertions.assertEquals("none", navitemInner1.css("box-shadow"));
+        Assertions.assertNotEquals("none", navitemInner2.css("box-shadow"));
+    }
+}

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/F102_ZK_5867Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/F102_ZK_5867Test.java
@@ -1,0 +1,67 @@
+/* F102_ZK_5867Test.java
+
+        Purpose:
+                
+        Description:
+                
+        History:
+                Thu Apr 17 17:40:12 CST 2025, Created by jamson
+
+Copyright (C) 2025 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Keys;
+
+import org.zkoss.test.webdriver.WebDriverTestCase;
+import org.zkoss.test.webdriver.ztl.JQuery;
+
+@Tag("WcagTestOnly")
+public class F102_ZK_5867Test extends WebDriverTestCase {
+
+    @Test
+    public void test() {
+        connect();
+        JQuery[][] jqueries = new JQuery[][] {
+                {
+                        jq("$rd input"),
+                        jq("$radiogrouprd1 input"),
+                        jq("$radiogrouprd2 input"),
+                },{
+                jq("$row1rd1 input"),
+                jq("$row1rd2 input"),
+                jq("$row2radiogrouprd1 input"),
+                jq("$row2radiogrouprd2 input"),
+                jq("$row3cb1 input"),
+                jq("$row3cb2 input")
+        }
+        };
+
+        for (JQuery[] jqs : jqueries) {
+            for (JQuery jq : jqs) {
+                assertUiFocusExists(jq, false);
+                if (jq.toString().contains("radiogrouprd2"))
+                    right();
+                else
+                    tab();
+                assertUiFocusExists(jq, true);
+            }
+            tab(); // for focus into grid
+        }
+    }
+
+    private void tab() {
+        getActions().sendKeys(Keys.TAB).perform();
+    }
+
+    private void right() {
+        getActions().sendKeys(Keys.ARROW_RIGHT).perform();
+    }
+
+    private void assertUiFocusExists(JQuery e, boolean exists) {
+        Assertions.assertEquals(exists, !"none".equals(e.css("box-shadow")));
+    }
+}

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/F102_ZK_5868Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/F102_ZK_5868Test.java
@@ -1,0 +1,43 @@
+/* F102_ZK_5868Test.java
+
+        Purpose:
+                
+        Description:
+                
+        History:
+                Thu Apr 17 18:00:33 CST 2025, Created by jamson
+
+Copyright (C) 2025 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Keys;
+
+import org.zkoss.test.webdriver.WebDriverTestCase;
+import org.zkoss.test.webdriver.ztl.JQuery;
+
+public class F102_ZK_5868Test extends WebDriverTestCase {
+
+    @Test
+    public void test() {
+        connect();
+        JQuery first = jq(".z-paging-first"),
+                previous = jq(".z-paging-previous"),
+                next = jq(".z-paging-next"),
+                last = jq(".z-paging-last");
+        Assertions.assertEquals("none", first.css("box-shadow"));
+        getActions().sendKeys(Keys.TAB).perform();
+        Assertions.assertNotEquals("none", first.css("box-shadow"));
+        Assertions.assertEquals("none", previous.css("box-shadow"));
+        getActions().sendKeys(Keys.TAB).perform();
+        Assertions.assertNotEquals("none", previous.css("box-shadow"));
+        Assertions.assertEquals("none", next.css("box-shadow"));
+        getActions().sendKeys(Keys.TAB, Keys.TAB).perform();
+        Assertions.assertNotEquals("none", next.css("box-shadow"));
+        Assertions.assertEquals("none", last.css("box-shadow"));
+        getActions().sendKeys(Keys.TAB).perform();
+        Assertions.assertNotEquals("none", last.css("box-shadow"));
+    }
+}

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/F102_ZK_5925Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/F102_ZK_5925Test.java
@@ -1,0 +1,33 @@
+/* F102_ZK_5925Test.java
+
+        Purpose:
+                
+        Description:
+                
+        History:
+                Thu Apr 17 16:04:03 CST 2025, Created by jamson
+
+Copyright (C) 2025 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Keys;
+
+import org.zkoss.test.webdriver.WebDriverTestCase;
+import org.zkoss.test.webdriver.ztl.JQuery;
+
+@Tag("WcagTestOnly")
+public class F102_ZK_5925Test extends WebDriverTestCase {
+
+    @Test
+    public void test() {
+        connect();
+        JQuery listheader = jq("@listheader");
+        Assertions.assertEquals("none", listheader.css("box-shadow"));
+        getActions().sendKeys(Keys.TAB, Keys.ARROW_DOWN, Keys.ARROW_UP).perform();
+        Assertions.assertNotEquals("none", listheader.css("box-shadow"));
+    }
+}

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/F102_ZK_5926Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/F102_ZK_5926Test.java
@@ -1,0 +1,33 @@
+/* F102_ZK_5926Test.java
+
+        Purpose:
+                
+        Description:
+                
+        History:
+                Thu Apr 17 16:14:53 CST 2025, Created by jamson
+
+Copyright (C) 2025 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Keys;
+
+import org.zkoss.test.webdriver.WebDriverTestCase;
+import org.zkoss.test.webdriver.ztl.JQuery;
+
+@Tag("WcagTestOnly")
+public class F102_ZK_5926Test extends WebDriverTestCase {
+
+    @Test
+    public void test() {
+        connect();
+        JQuery column = jq("@column");
+        Assertions.assertEquals("none", column.css("box-shadow"));
+        getActions().sendKeys(Keys.TAB, Keys.ARROW_UP).perform();
+        Assertions.assertNotEquals("none", column.css("box-shadow"));
+    }
+}

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/F102_ZK_5930Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/F102_ZK_5930Test.java
@@ -1,0 +1,55 @@
+/* F102_ZK_5930Test.java
+
+        Purpose:
+                
+        Description:
+                
+        History:
+                Thu Apr 24 15:18:10 CST 2025, Created by jamson
+
+Copyright (C) 2025 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Keys;
+
+import org.zkoss.test.webdriver.WebDriverTestCase;
+import org.zkoss.test.webdriver.ztl.JQuery;
+
+@Tag("WcagTestOnly")
+public class F102_ZK_5930Test extends WebDriverTestCase {
+    
+    @Test
+    public void test() {
+        connect();
+        assertFocusedCell(-1, -1); // no focused cell
+        getActions().sendKeys(Keys.TAB).perform();
+        assertFocusedCell(0, 0);
+        getActions().sendKeys(Keys.ARROW_RIGHT).perform();
+        assertFocusedCell(0, 1);
+        getActions().sendKeys(Keys.ARROW_DOWN).perform();
+        assertFocusedCell(1, 1);
+        getActions().sendKeys(Keys.ARROW_LEFT).perform();
+        assertFocusedCell(1, 0);
+    }
+    
+    private void assertFocusedCell(int y, int x) {
+        JQuery rows = jq("@row");
+        int m = rows.length();
+        for (int i = 0; i < m; i++) {
+            JQuery cells = rows.eq(i).find("@cell");
+            int n = cells.length();
+            for (int j = 0; j < n; j++) {
+                JQuery cell = cells.eq(j);
+                if (i == y && j == x) {
+                    Assertions.assertNotEquals("none", cell.css("box-shadow"));
+                } else {
+                    Assertions.assertEquals("none", cell.css("box-shadow"));
+                }
+            }
+        }
+    }
+}

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/F102_ZK_5932Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/F102_ZK_5932Test.java
@@ -1,0 +1,33 @@
+/* F102_ZK_5932Test.java
+
+        Purpose:
+                
+        Description:
+                
+        History:
+                Mon Apr 28 11:25:26 CST 2025, Created by jamson
+
+Copyright (C) 2025 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Keys;
+
+import org.zkoss.test.webdriver.WebDriverTestCase;
+import org.zkoss.test.webdriver.ztl.JQuery;
+
+@Tag("WcagTestOnly")
+public class F102_ZK_5932Test extends WebDriverTestCase {
+
+    @Test
+    public void test() {
+        connect();
+        JQuery cm = jq(".z-listheader-checkable");
+        Assertions.assertEquals("none", cm.css("box-shadow"));
+        getActions().sendKeys(Keys.TAB, Keys.ARROW_DOWN, Keys.ARROW_UP).perform();
+        Assertions.assertNotEquals("none", cm.css("box-shadow"));
+    }
+}

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/F102_ZK_5933Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/F102_ZK_5933Test.java
@@ -1,0 +1,33 @@
+/* F102_ZK_5933Test.java
+
+        Purpose:
+                
+        Description:
+                
+        History:
+                Mon Apr 28 11:27:24 CST 2025, Created by jamson
+
+Copyright (C) 2025 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Keys;
+
+import org.zkoss.test.webdriver.WebDriverTestCase;
+import org.zkoss.test.webdriver.ztl.JQuery;
+
+@Tag("WcagTestOnly")
+public class F102_ZK_5933Test extends WebDriverTestCase {
+
+    @Test
+    public void test() {
+        connect();
+        JQuery cm = jq(".z-treecol-checkable");
+        Assertions.assertEquals("none", cm.css("box-shadow"));
+        getActions().sendKeys(Keys.TAB, Keys.ARROW_DOWN, Keys.ARROW_UP).perform();
+        Assertions.assertNotEquals("none", cm.css("box-shadow"));
+    }
+}

--- a/zul/src/main/resources/web/js/zul/grid/less/grid.less
+++ b/zul/src/main/resources/web/js/zul/grid/less/grid.less
@@ -64,6 +64,10 @@
 	.z-row-inner, .z-cell {
 		background: @meshBackgroundColor;
 	}
+	.z-cell:focus-visible {
+		box-shadow: @meshCellFocusBoxShadow;
+		transition: unset;
+	}
 	&-odd > .z-row-inner,
 	&-odd > .z-cell {
 		background: @meshStripeBackgroundColor;
@@ -130,6 +134,10 @@
 	overflow: hidden;
 	white-space: nowrap;
 
+	&:focus-visible {
+		box-shadow: @meshTitleFocusBoxShadow;
+		transition: unset;
+	}
 	&-button {
 		.iconFontStyle(@fontSizeLarge, @meshTitleColor);
 		display: none;

--- a/zul/src/main/resources/web/js/zul/mesh/less/paging.less
+++ b/zul/src/main/resources/web/js/zul/mesh/less/paging.less
@@ -36,6 +36,11 @@
 		text-decoration: none;
 		white-space: nowrap;
 		
+		&:focus-visible {
+			box-shadow: @pagingButtonFocusBoxShadow;
+			transition: unset;
+			border-radius: @pagingButtonFocusBorderRadius;
+		}
 		&:hover {
 			background-color: @pagingItemHoverBackgroundColor;
 		}

--- a/zul/src/main/resources/web/js/zul/sel/less/listbox.less
+++ b/zul/src/main/resources/web/js/zul/sel/less/listbox.less
@@ -33,6 +33,10 @@
 	border: 1px solid @baseBorderColor;
 	overflow: hidden;
 	zoom: 1;
+	&:focus-visible {
+		box-shadow: @meshFocusBoxShadow;
+		transition: unset;
+	}
 	//listbox header
 	&-header {
 		width: 100%;
@@ -110,6 +114,10 @@
 	position: relative;
 	overflow: hidden;
 	white-space: nowrap;
+	&:focus-visible {
+		box-shadow: @meshTitleFocusBoxShadow;
+		transition: unset;
+	}
 	&-sort {
 		.z-listheader-content {
 			cursor: pointer;
@@ -151,6 +159,10 @@
 	&-checkable {
 		.checkable();
 		
+		&:focus-visible {
+			box-shadow: @meshTitleFocusBoxShadow;
+			transition: unset;
+		}
 		.z-listheader-icon {
 			display: none;
 			cursor: default;
@@ -261,7 +273,19 @@
 	}
 	&-focus {
 		> .z-listcell {
-			background: @meshContentFocusBackgroundColor;
+			.listitemFocusBorder(@left: 0, @right: 0) {
+				box-shadow: inset 0 2px 0 0 @meshCellFocusBoxShadowColor,
+							inset 0 -2px 0 0 @meshCellFocusBoxShadowColor,
+							inset @left 0 0 0 @meshCellFocusBoxShadowColor,
+							inset -@right 0 0 0 @meshCellFocusBoxShadowColor;
+			}
+			.listitemFocusBorder();
+			&:first-child {
+				.listitemFocusBorder(@left: 2px);
+			}
+			&:last-child {
+				.listitemFocusBorder(@right: 2px);
+			}
 		}
 		.z-listcell-content {
 			color: @hoverColor;

--- a/zul/src/main/resources/web/js/zul/sel/less/tree.less
+++ b/zul/src/main/resources/web/js/zul/sel/less/tree.less
@@ -20,6 +20,10 @@
 	border: 1px solid @baseBorderColor;
 	overflow: hidden;
 	zoom: 1;
+	&:focus-visible {
+		box-shadow: @meshFocusBoxShadow;
+		transition: unset;
+	}
 	//tree header div
 	&-header {
 		width: 100%;
@@ -121,6 +125,10 @@
 	position: relative;
 	overflow: hidden;
 	white-space: nowrap;
+	&:focus-visible {
+		box-shadow: @meshTitleFocusBoxShadow;
+		transition: unset;
+	}
 	&-sort {
 		cursor: pointer;
 
@@ -149,6 +157,10 @@
 		margin-right: 8px;
 		.borderRadius(@baseBorderRadius);
 
+		&:focus-visible {
+			box-shadow: @meshTitleFocusBoxShadow;
+			transition: unset;
+		}
 		.z-treecol-icon {
 			display: none;
 			cursor: default;
@@ -201,7 +213,19 @@
 
 	&-focus {
 		> .z-treecell {
-			background: @meshContentFocusBackgroundColor;
+			.treeitemFocusBorder(@left: 0, @right: 0) {
+				box-shadow: inset 0 2px 0 0 @meshCellFocusBoxShadowColor,
+							inset 0 -2px 0 0 @meshCellFocusBoxShadowColor,
+							inset @left 0 0 0 @meshCellFocusBoxShadowColor,
+							inset -@right 0 0 0 @meshCellFocusBoxShadowColor;
+			}
+			.treeitemFocusBorder();
+			&:first-child {
+				.treeitemFocusBorder(@left: 2px);
+			}
+			&:last-child {
+				.treeitemFocusBorder(@right: 2px);
+			}
 			> .z-treecell-content {
 				color: @hoverColor;
 			}

--- a/zul/src/main/resources/web/js/zul/wgt/less/checkbox.less
+++ b/zul/src/main/resources/web/js/zul/wgt/less/checkbox.less
@@ -1,8 +1,16 @@
 @import "~./zul/less/_header.less";
 
 .z-checkbox {
+	&-default > input[type="checkbox"]:focus-visible {
+		box-shadow: 0 0 0 2px @focusBorderColor;
+		transition: unset;
+	}
 	&-default > &-mold {
 		display: none;
+	}
+	&-tristate > input[type="checkbox"]:focus-visible {
+		box-shadow: 0 0 0 2px @focusBorderColor;
+		transition: unset;
 	}
 	&-tristate > &-mold {
 		display: none;

--- a/zul/src/main/resources/web/js/zul/wgt/less/groupbox.less
+++ b/zul/src/main/resources/web/js/zul/wgt/less/groupbox.less
@@ -93,6 +93,12 @@
 				top: 0;
 			}
 
+			.z-caption:has(> span:focus-visible) .z-caption-content {
+				box-shadow: @groupboxFocusBoxShadow;
+				transition: unset;
+				border-radius: @groupboxFocusBorderRadius;
+			}
+
 			.z-caption-content, .z-groupbox-title-content {
 				line-height: @baseIconHeight;
 				font-size: @groupboxHeaderFontSize;
@@ -108,5 +114,11 @@
 		> .z-groupbox-content {
 			padding: @groupbox3DContentPadding;
 		}
+	}
+
+	&:not(.z-groupbox-3d) > .z-groupbox-header .z-caption:has(> span:focus-visible) {
+		box-shadow: @groupboxFocusBoxShadow;
+		transition: unset;
+		border-radius: @groupboxFocusBorderRadius;
 	}
 }

--- a/zul/src/main/resources/web/zul/less/_zkvariables.less
+++ b/zul/src/main/resources/web/zul/less/_zkvariables.less
@@ -114,6 +114,12 @@
 @treecellContentLineHeight:    @baseLineHeight;
 @listheaderCheckedPositionLeft: 0;
 @listboxRadioIconSize:         10px;
+@meshFocusBoxShadowColor:      @colorAccent;
+@meshTitleFocusBoxShadowColor: @colorAccent;
+@meshCellFocusBoxShadowColor:  @colorPrimary;
+@meshFocusBoxShadow:           0 0 0 2px @meshFocusBoxShadowColor;
+@meshTitleFocusBoxShadow:      inset 0 0 0 2px @meshTitleFocusBoxShadowColor;
+@meshCellFocusBoxShadow:       inset 0 0 0 2px @meshCellFocusBoxShadowColor;
 
 // -------------------------------------
 // Component State
@@ -235,6 +241,9 @@
 @groupboxNotitleContentPadding:@containerPadding;
 @groupbox3DHeaderPadding:      12px 16px;
 @groupbox3DContentPadding:     @containerPadding;
+@groupboxFocusBoxShadowColor:  @colorPrimary;
+@groupboxFocusBoxShadow:       0 0 0 2px @groupboxFocusBoxShadowColor;
+@groupboxFocusBorderRadius:    @baseBorderRadius;
 
 // Toolbar
 @toolbarHorizontalPadding:     16px;
@@ -498,6 +507,9 @@
 @pagingButtonFontSize:         @fontSizeLarge;
 @pagingButtonPadding:          4px;
 @pagingButtonMargin:           5px 0;
+@pagingButtonFocusBoxShadowColor:    @colorPrimary;
+@pagingButtonFocusBoxShadow:         0 0 0 2px @pagingButtonFocusBoxShadowColor;
+@pagingButtonFocusBorderRadius:      @baseBorderRadius;
 @pagingIconSize:               @fontSizeLarge;
 @pagingIconLineHeight:         @baseLineHeight;
 @pagingInputHeight:            36px;
@@ -660,6 +672,8 @@
 @navTextPopupPadding:          4px 18px;
 @navTextPopupLineHeight:       @baseBarHeight;
 @navbarCollapsedInfoPositionTop: -2px;
+@navitemFocusBoxShadowColor:     @colorPrimary;
+@navitemFocusBoxShadow:          0 0 0 2px @navitemFocusBoxShadowColor;
 
 // chosenbox
 @chosenboxIconSize:            @fontSizeMedium;

--- a/zul/src/main/resources/web/zul/less/norm.less
+++ b/zul/src/main/resources/web/zul/less/norm.less
@@ -173,6 +173,11 @@ div.z-log {
 		border-color: @checkboxHoverBorderColor;
 	}
 
+	&:focus-visible {
+		box-shadow: 0 0 0 2px @focusBorderColor;
+		transition: unset;
+	}
+
 	&:before {
 		content: '';
 		.displaySize(block, 12px, 12px);


### PR DESCRIPTION
ZK-5867: Radio can show its focused state
ZK-5395: Listbox can show its focused state
ZK-5486: za11y: Support showing when a Listbox receives focus via keyboard
ZK-5925: Listheader can show its focused state
ZK-5497: Tree can show its focused state
ZK-5499: Treecol can show its focused state
ZK-5926: Column can show its focused state
ZK-5930: Cell can show its focused state
ZK-5518: Groupbox can show its focused state
ZK-5521: Nav can show its focused state
ZK-5868: Paging can show its focused state
ZK-5932: Listheader's checkbox can show its focused state
ZK-5933: Treecol's checkbox can show its focused state
ZK-5648: listbox focused item and selected item has the same background color
ZK-5882: tree focused item and selected item has the same background color


This PR should be merged alongside https://github.com/zkoss/zkcml/pull/1217