### PR TITLE
ZK-4861: Inconsistent input options in Android, cause unreliable timebox input

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -18,6 +18,7 @@ ZK 10.2.0
   ZK-5231: removing a barcodescanner immediately right after the browser renders it causes javascript error
   ZK-5898: QR code scanning does not work in Barcodescanner
   ZK-4337: barcodescanner can only instantiate reader once per page
+  ZK-4861: Inconsistent input options in Android, cause unreliable timebox input
 
 * Upgrade Notes
   + Remove the Fragment component from the zkmax.jar and use the new Client MVVM  (client-bind.jar) library instead.

--- a/zktest/src/main/webapp/test2/B102-ZK-4861.zul
+++ b/zktest/src/main/webapp/test2/B102-ZK-4861.zul
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+B102-ZK-4861.zul
+
+        Purpose:
+
+        Description:
+
+        History:
+                Mon Apr 14 12:39:11 CST 2025, Created by jamson
+
+Copyright (C) 2025 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+    <script>
+        zk.tabletUIEnabled = false;
+    </script>
+    
+    <label multiline="true">
+        1. Run with Android device, or Android Studio Emulator
+        2. Using backspace to clear the contents in the timebox, and type an invalid value of time (e.g. "foobar")
+        3. The input value shows in the timebox should stay empty (not changed)
+        4. Using backspace to clear the contents in the timebox, and type a valid value of time (e.g. 05:16)
+        5. The input value shows in the timebox should be changed, and the label of a red border should have new content (timebox onChange triggered)
+    </label>
+    <timebox format="hh:mm" onChange='lb.setValue(self.getValue().toString())'/>
+    <label id="lb" style="border: 1px solid red"/>
+</zk>

--- a/zktest/src/main/webapp/test2/config.properties
+++ b/zktest/src/main/webapp/test2/config.properties
@@ -3164,6 +3164,7 @@ B90-ZK-4431.zul=A,E,Multislider
 ##manually##B102-ZK-5230-1.zul=A,E,Barcodescanner
 ##manually##B102-ZK-5230.zul=A,E,Barcodescanner
 ##manually##B102-ZK-4337.zul=A,E,Barcodescanner
+##ztl##B102-ZK-4861.zul=A,E,Android,Chrome,Timebox
 
 ##
 # Features - 3.0.x version


### PR DESCRIPTION
This PR should be merged alongside https://github.com/zkoss/ztltest/pull/401