### PR TITLE
ZK-5461: Provide easy-to-override headers functions to client-side re…

### DIFF
--- a/zk/src/main/resources/web/js/zk/au.ts
+++ b/zk/src/main/resources/web/js/zk/au.ts
@@ -224,6 +224,7 @@ function ajaxSendNow(reqInf: AuRequestInfo): void {
 		headers: reqInf.content instanceof FormData ? { 'ZK-SID': '' + reqInf.sid } : { 'Content-Type': zAu.ajaxSettings.contentType, 'ZK-SID': '' + reqInf.sid },
 		body: reqInf.content
 	};
+	Object.assign(fetchOpts.headers!, zAu.getExtraHeaders());
 	zAu.sentTime = Date.now(); //used by server-push (cpsp)
 	zk.ausending = true;
 	if (zk.xhrWithCredentials)
@@ -551,6 +552,15 @@ export namespace au_global {
 		 */
 		export function processing(): boolean {
 			return zk.mounting || !!cmdsQue.length || !!zAu.ajaxReq || !!zAu.pendingReqInf;
+		}
+
+		/**
+		 * @returns extra headers that will be passed for each AU request to the server,
+		 * please note that this will be ignored for requests via websocket and rmDesktop.
+		 * @since 10.2.0
+		 */
+		export function getExtraHeaders(): Record<string, string> {
+			return {};
 		}
 
 		/**

--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -3,6 +3,8 @@ ZK 10.2.0
   ZK-5824: separate fragment widget into an independent library or another jar
   ZK-5392: support a way to disable dates
   ZK-5016: Pass all errors as a List<Throwable> to custom error page
+  ZK-5461: Provide easy-to-override headers functions to client-side request emitters
+  ZK-5438: Support a way to work with Spring Security CSRF
 
 * Bugs
   ZK-5728: ZK-5364 causes external radio to no longer be selected / checked

--- a/zktest/src/main/webapp/test2/F102-ZK-5461.zul
+++ b/zktest/src/main/webapp/test2/F102-ZK-5461.zul
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+F102-ZK-5461.zul
+
+        Purpose:
+
+        Description:
+
+        History:
+                Thu Apr 10 16:27:35 CST 2025, Created by rebeccalai
+
+Copyright (C) 2025 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+	<label multiline="true">
+		1. open chrome devtools, go to network tab
+		2. click the button to send a zkau request
+		3. check for custom 'myKey' request header
+	</label>
+	<script><![CDATA[
+	zk.afterLoad(function () {
+		const {getExtraHeaders} = zk.augment(zAu, {
+			getExtraHeaders() {
+				const extraHeaders = getExtraHeaders();
+				extraHeaders['myKey'] = 'myValue';
+				return extraHeaders;
+			}
+		});
+	});
+	]]></script>
+	<button label="button" onClick=''/>
+</zk>

--- a/zktest/src/main/webapp/test2/config.properties
+++ b/zktest/src/main/webapp/test2/config.properties
@@ -3791,6 +3791,7 @@ F86-ZK-4235.zul=A,E,datefmt,library-property
 #F102
 ##zats##F102-ZK-5392.zul=A,E,Datebox,disable,date
 ##zats##F102-ZK-5016.zul=A,E,error-page,exception_list
+##zats##F102-ZK-5461.zul=A,E,AuRequest,RequestHeader,zAu
 
 # Complex Test Case
 #

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/F102_ZK_5461Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/F102_ZK_5461Test.java
@@ -1,0 +1,40 @@
+/* F102_ZK_5461Test.java
+
+        Purpose:
+                
+        Description:
+                
+        History:
+                Fri Apr 11 12:16:39 CST 2025, Created by rebeccalai
+
+Copyright (C) 2025 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.devtools.DevTools;
+import org.openqa.selenium.devtools.v130.network.Network;
+
+import org.zkoss.test.webdriver.WebDriverTestCase;
+
+public class F102_ZK_5461Test extends WebDriverTestCase {
+	@Test
+	public void test() {
+		connect();
+		Map<String, Object> headers = new HashMap<>();
+		DevTools devTools = ((ChromeDriver) driver).getDevTools();
+		devTools.createSession();
+		devTools.send(Network.enable(Optional.empty(), Optional.empty(), Optional.empty()));
+		devTools.addListener(Network.requestWillBeSent(), request -> headers.putAll(request.getRequest().getHeaders()));
+		click(jq("@button"));
+		waitResponse();
+		assertEquals("myValue", headers.get("myKey"));
+	}
+}


### PR DESCRIPTION
…quest emitters to support ZK-5438: Support a way to work with Spring Security CSRF