### PR TITLE
ZK-5674: i11n labels does not load in a shadow element in client-mvvm

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -92,6 +92,7 @@ ZK 10.2.0
   ZK-5758: Unrelated load bindings are notified unexpectedly
   ZK-5913: Incorrect parsing for two digit year
   ZK-5803: draggable creates stackup iframes, may no longer be necessary after IE support end
+  ZK-5674: i11n labels does not load in a shadow element in client-mvvm
 
 * Upgrade Notes
   + Remove the Fragment component from the zkmax.jar and use the new Client MVVM  (client-bind.jar) library instead.


### PR DESCRIPTION
This PR should be merge alongside zkoss/zkcml#1248