### PR TITLE
ZK-5718: deprecated feature used in client-bind reported by Chrome

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -63,6 +63,7 @@ ZK 10.3.0
   ZK-5606: Statistic returns incorrect average number when escaped hour is less then 1 hour
   ZK-5588: combobox doesn't highlight the matched item when pasting value via a mouse
   ZK-5375: Borderlayout regions do not resize when borderlayout resizes
+  ZK-5718: deprecated feature used in client-bind reported by Chrome
 
 * Upgrade Notes
   + add OSGi header into all ZK jars without additional OSGi bundles.

--- a/zktest/src/main/webapp/test2/config.properties
+++ b/zktest/src/main/webapp/test2/config.properties
@@ -3261,6 +3261,7 @@ B90-ZK-4431.zul=A,E,Multislider
 ##Manually##B103-ZK-5588.zul=A,E,Combobox
 ##zats##B103-ZK-5870.zul=A,E,Fileupload, websocket
 ##zats##B103-ZK-5375.zul=A,E,Borderlayout,resize
+##zats##B103-ZK-5718.zul=A,E,client-bind,Chrome,deprecated,unload,beforeunload
 
 ##
 # Features - 3.0.x version


### PR DESCRIPTION
This should be merged alongside https://github.com/zkoss/zkcml/pull/1295