### PR TITLE
ZK-6075: URL exception in IBM WebSphere / Open Liberty

### DIFF
--- a/zcommon/src/main/java/org/zkoss/util/URLs.java
+++ b/zcommon/src/main/java/org/zkoss/util/URLs.java
@@ -25,48 +25,31 @@ import org.apache.hc.core5.net.URIBuilder;
 public class URLs {
 
 	/**
-	 * Sanitizes a URL to prevent MalformedURLException and SSRF warning.
+	 * Sanitizes a URL for resource loading.
+	 *
+	 * <p>Only {@code http}/{@code https} URLs keep the legacy URIBuilder rebuild;
+	 * a URL of any other protocol is returned unchanged, so the declared
+	 * exceptions can only be thrown for {@code http}/{@code https} URLs.
 	 *
 	 * @param url The URL to be sanitized.
 	 * @return The sanitized URL.
-	 * @throws MalformedURLException If the URL is not in the correct format.
-	 * @throws URISyntaxException If the URL is not formatted strictly according to RFC2396 and cannot be converted to a URI.
+	 * @throws MalformedURLException If an http/https URL cannot be reconstructed.
+	 * @throws URISyntaxException If an http/https URL is not formatted strictly according to RFC2396 and cannot be converted to a URI.
 	 */
 	public static URL sanitizeURL(URL url) throws MalformedURLException, URISyntaxException {
 		if (url == null) return null;
 
-		// Handle JAR URLs specially - they have protocol "jar" and contain "!/" separator
-		if ("jar".equals(url.getProtocol())) {
-			// For JAR URLs, getFile() returns the full jar path with "!/" separator
-			// e.g., "file:/path/to/lib.jar!/META-INF/resources/js/file.js"
-			String jarSpec = url.getFile();
-			if (jarSpec != null && jarSpec.contains("!/")) {
-				int separatorIndex = jarSpec.indexOf("!/");
-				String jarFilePath = jarSpec.substring(0, separatorIndex);
-				String internalPath = jarSpec.substring(separatorIndex + 2);
-
-				if (jarFilePath.isEmpty() || internalPath.isEmpty()) {
-					throw new MalformedURLException("Invalid JAR URL format: empty jar path or internal path");
-				}
-
-				// Sanitize the jar file URL (e.g., "file:/path/to/lib.jar")
-				// Validate by parsing through URL and URI, but preserve original format
-				URL jarURL = new URL(jarFilePath);
-
-				// Validate the URL can be converted to URI (SSRF check)
-				jarURL.toURI();
-
-				// Reconstruct the JAR URL preserving the original jar path format
-				return new URL("jar:" + jarFilePath + "!/" + internalPath);
-			} else {
-				throw new MalformedURLException("Invalid JAR URL format: missing !/ separator");
-			}
-		} else {
-			// For regular URLs, prevent SSRF warning by reconstructing via URI
-			return new URIBuilder().setScheme(url.getProtocol())
+		String protocol = url.getProtocol();
+		// Preserve the existing http/https behavior. Any other protocol
+		// (file, jar, wsjar, vfs, ftp, ...) is returned untouched - its format is owned by its
+		// URLStreamHandler, and rebuilding may corrupt it (e.g. percent-encode
+		// the separators of a nested JAR URL, or drop the user-info).
+		if ("http".equals(protocol) || "https".equals(protocol)) {
+			return new URIBuilder().setScheme(protocol)
 					.setHost(url.getHost()).setPort(url.getPort())
 					.setPath(url.getPath())
 					.setCustomQuery(url.getQuery()).build().toURL();
 		}
+		return url;
 	}
 }

--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -22,8 +22,10 @@ ZK 10.4.0
   ZK-5259: Radiogroup external radio items lost after setPage
   ZK-6092: DOMPurify: Fix XSS vulnerabilities CVE-2026-0540 and CVE-2025-15599
   ZK-6079: zul.xsd : toolbar only allows one child component instead of multiple
+  ZK-6075: URL exception in IBM WebSphere / Open Liberty
 
 * Upgrade Notes
+  + URLs.sanitizeURL now returns non-http/https URLs unchanged. Applications that call this public API directly should not rely on it to validate or reject container-owned resource URL formats such as jar/wsjar URLs without an entry separator.
 
    --------
 ZK 10.3.0

--- a/zktest/src/main/webapp/test2/B104-ZK-6075.zul
+++ b/zktest/src/main/webapp/test2/B104-ZK-6075.zul
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+B104-ZK-6075.zul
+
+		Purpose:
+
+		Description:
+
+		History:
+				Tue Mar 25 17:09:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+	<label multiline="true">
+		ZK-6075: URL exception in IBM WebSphere / Open Liberty
+
+		The url.getProtocol() in URLs returns "wsjar" in IBM WebSphere / Open Liberty,
+		which caused MalformedURLException because URLs.sanitizeURL() only handled "jar" protocol.
+
+		Steps to reproduce:
+		1. Deploy a ZK application on IBM WebSphere or Open Liberty
+		2. Open a ZUL page that loads resources from JAR files
+		3. Check server logs for MalformedURLException
+
+		To verify the fix:
+		- Expected: No MalformedURLException in server logs, page loads correctly
+		- The fix: URLs.sanitizeURL() only normalizes network (http/https) URLs via
+		  URIBuilder; any other protocol (jar, wsjar, file, vfs, ...) is returned
+		  untouched, restoring the pre-10.0.1 behavior
+	</label>
+</zk>

--- a/zktest/src/main/webapp/test2/config.properties
+++ b/zktest/src/main/webapp/test2/config.properties
@@ -3287,6 +3287,7 @@ B90-ZK-4431.zul=A,E,Multislider
 ##zats##B104-ZK-5259.zul=A,E,Radiogroup,Radio
 ##zats##B104-ZK-6092.zul=A,E,DOMPurify,XSS,security
 ##zats##B104-ZK-6079.zul=A,E,Toolbar,Toolbarbutton,zul.xsd
+##zats##B104-ZK-6075.zul=A,E,URL,WebSphere,Liberty,wsjar
 
 ##
 # Features - 3.0.x version

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B103_ZK_5877Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B103_ZK_5877Test.java
@@ -105,7 +105,8 @@ public class B103_ZK_5877Test {
 
 	@Test
 	public void testSanitizeInvalidJarURLMissingSeparator() {
-		// Test JAR URL without !/ separator - should throw exception
+		// A jar URL without "!/" is rejected by the JDK jar handler in the
+		// URL constructor itself, before sanitizeURL is reached.
 		assertThrows(MalformedURLException.class, () -> {
 			URL jarUrl = new URL("jar:file:/path/to/lib.jar");
 			URLs.sanitizeURL(jarUrl);
@@ -139,7 +140,8 @@ public class B103_ZK_5877Test {
 		URL sanitized = URLs.sanitizeURL(jarUrl);
 
 		assertNotNull(sanitized);
-		// Verify the URL is properly reconstructed through URIBuilder
+		// The jar URL is returned unchanged; verify the format (protocol and
+		// "!/" separator) is preserved exactly
 		assertEquals("jar", sanitized.getProtocol());
 		assertEquals("file:/legitimate/path/lib.jar!/internal/path/file.js", sanitized.getFile());
 	}

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B104_ZK_6075Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B104_ZK_6075Test.java
@@ -1,0 +1,198 @@
+/* B104_ZK_6075Test.java
+
+        Purpose:
+
+        Description:
+
+        History:
+                Wed Mar 25 17:24:36 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+import java.net.URLStreamHandlerFactory;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.zkoss.util.URLs;
+
+public class B104_ZK_6075Test {
+
+	@BeforeAll
+	public static void setup() {
+		try {
+			// Register a wsjar URL handler that mirrors how IBM WebSphere / Open Liberty
+			// parse "wsjar:file:/...jar!/inner" — i.e. the same way the JDK's built-in
+			// jar handler does. Without overriding parseURL, the JDK default parser
+			// mangles the inner "file:/...!/..." structure and the test wouldn't
+			// reproduce the production behavior.
+			URL.setURLStreamHandlerFactory(new URLStreamHandlerFactory() {
+				@Override
+				public URLStreamHandler createURLStreamHandler(String protocol) {
+					if ("wsjar".equals(protocol)) {
+						return new URLStreamHandler() {
+							@Override
+							protected URLConnection openConnection(URL u) {
+								return null;
+							}
+							@Override
+							protected void parseURL(URL u, String spec, int start, int limit) {
+								String file = spec.substring(start, limit);
+								setURL(u, "wsjar", "", -1, null, null, file, null, null);
+							}
+						};
+					}
+					return null;
+				}
+			});
+		} catch (Error e) {
+			// URL.setURLStreamHandlerFactory may only be called once per JVM.
+		}
+	}
+
+	@Test
+	public void testSanitizeWsjarURL() throws Exception {
+		// Simulate a wsjar URL as produced by IBM WebSphere / Open Liberty
+		URL wsjarUrl = new URL("wsjar:file:/path/to/server/workarea/cache/WEB-INF/lib/zweb-10.3.0.1-jakarta.jar!/web/WEB-INF/tld/web/theme.dsp.tld");
+		URL sanitized = URLs.sanitizeURL(wsjarUrl);
+
+		assertNotNull(sanitized);
+		assertEquals("wsjar", sanitized.getProtocol());
+		assertEquals("file:/path/to/server/workarea/cache/WEB-INF/lib/zweb-10.3.0.1-jakarta.jar!/web/WEB-INF/tld/web/theme.dsp.tld", sanitized.getFile());
+		// The actual ZK-6075 bug: without the fix, ":" and "!" inside the inner file: URL
+		// got URL-encoded to "%3A" and "%21", causing "no protocol: file%3A/..." downstream.
+		assertNoEncodedSeparators(sanitized);
+	}
+
+	@Test
+	public void testSanitizeWsjarURLWithZkResources() throws Exception {
+		// Path mirroring the one from the reported FFDC log
+		URL wsjarUrl = new URL("wsjar:file:/Users/user/Downloads/openliberty/wlp/usr/servers/defaultServer/workarea/org.eclipse.osgi/64/data/cache/zk10301-liberty-repro/.cache/WEB-INF/lib/zweb-10.3.0.1-jakarta.jar!/web/WEB-INF/tld/web/theme.dsp.tld");
+		URL sanitized = URLs.sanitizeURL(wsjarUrl);
+
+		assertNotNull(sanitized);
+		assertEquals("wsjar", sanitized.getProtocol());
+		assertNoEncodedSeparators(sanitized);
+	}
+
+	@Test
+	public void testSanitizeWsjarURLPreservesProtocol() throws Exception {
+		// Verify the protocol stays "wsjar" — not silently rewritten to "jar"
+		URL wsjarUrl = new URL("wsjar:file:/opt/ibm/wlp/lib/zul-10.3.0.1.jar!/js/zul/wgt/mold/inputgroup.js");
+		URL sanitized = URLs.sanitizeURL(wsjarUrl);
+
+		assertNotNull(sanitized);
+		assertEquals("wsjar", sanitized.getProtocol());
+		assertEquals("file:/opt/ibm/wlp/lib/zul-10.3.0.1.jar!/js/zul/wgt/mold/inputgroup.js", sanitized.getFile());
+		assertNoEncodedSeparators(sanitized);
+	}
+
+	@Test
+	public void testSanitizeJarURLStillWorks() throws Exception {
+		// Ensure regular jar URLs still work after the change
+		URL jarUrl = new URL("jar:file:/path/to/lib.jar!/META-INF/resources/js/file.js");
+		URL sanitized = URLs.sanitizeURL(jarUrl);
+
+		assertNotNull(sanitized);
+		assertEquals("jar", sanitized.getProtocol());
+		assertEquals("file:/path/to/lib.jar!/META-INF/resources/js/file.js", sanitized.getFile());
+		assertNoEncodedSeparators(sanitized);
+	}
+
+	@Test
+	public void testSanitizeWsjarURLWithoutSeparatorIsReturnedAsIs() throws Exception {
+		// ZK-6075 loosening: a JAR-family URL whose file part lacks the "!/"
+		// entry separator (e.g. a bare wsjar-wrapped jar) must no longer be
+		// rejected with MalformedURLException; non-network URLs are returned
+		// unchanged instead of being forced into a "<jar>!/<entry>" shape.
+		URL wsjarUrl = new URL("wsjar:file:/opt/ibm/wlp/lib/zul-10.3.0.1.jar");
+		URL sanitized = URLs.sanitizeURL(wsjarUrl);
+
+		assertNotNull(sanitized);
+		assertEquals("wsjar", sanitized.getProtocol());
+		assertEquals("file:/opt/ibm/wlp/lib/zul-10.3.0.1.jar", sanitized.getFile());
+		assertNoEncodedSeparators(sanitized);
+	}
+
+	@Test
+	public void testSanitizeFileURLWithEncodedCharsNotDoubleEncoded() throws Exception {
+		// A file URL whose path is already percent-encoded (e.g. an exploded
+		// WAR under "Program Files") must be returned untouched: rebuilding it
+		// via URIBuilder re-encoded "%20" to "%2520", which no longer resolves
+		// (FileNotFoundException at openStream).
+		URL fileUrl = new URL("file:/C:/Program%20Files/app/webroot/js/span.js");
+		URL sanitized = URLs.sanitizeURL(fileUrl);
+
+		assertNotNull(sanitized);
+		assertEquals("file:/C:/Program%20Files/app/webroot/js/span.js", sanitized.toString());
+		assertFalse(sanitized.toString().contains("%2520"),
+				"already-encoded path must not be double-encoded: " + sanitized);
+	}
+
+	@Test
+	public void testSanitizeFileURLWithRawSpaceDoesNotThrow() throws Exception {
+		// Pre-10.0.1 behavior restored: no URI-strictness is imposed on
+		// non-network URLs; whatever the container hands us is returned as-is
+		// (Servlets.getResourceAsStream would otherwise turn a working
+		// deployment into "resource not found").
+		URL fileUrl = new URL("file:/path/my lib/file.js");
+		URL sanitized = URLs.sanitizeURL(fileUrl);
+
+		assertNotNull(sanitized);
+		assertEquals("file:/path/my lib/file.js", sanitized.toString());
+	}
+
+	@Test
+	public void testSanitizeFtpURLPreservesCredentials() throws Exception {
+		// ftp is not in the http/https normalization list; it must pass through
+		// untouched. The URIBuilder rebuild silently dropped the user-info
+		// ("user:pass@") because it never called setUserInfo, breaking
+		// authenticated ftp resources.
+		URL ftpUrl = new URL("ftp://user:pass@host:2121/dir/file.bin");
+		URL sanitized = URLs.sanitizeURL(ftpUrl);
+
+		assertNotNull(sanitized);
+		assertEquals("ftp://user:pass@host:2121/dir/file.bin", sanitized.toString());
+		assertEquals("user:pass", sanitized.getUserInfo());
+	}
+
+	@Test
+	public void testSanitizeFtpURLWithEncodedCharsNotDoubleEncoded() throws Exception {
+		// ftp is a supported resource URI in Servlets.toURL(); an already-encoded
+		// path must not be rebuilt through URIBuilder and re-encoded to "%2520".
+		URL ftpUrl = new URL("ftp://host/my%20dir/file.bin");
+		URL sanitized = URLs.sanitizeURL(ftpUrl);
+
+		assertNotNull(sanitized);
+		assertEquals("ftp://host/my%20dir/file.bin", sanitized.toString());
+		assertFalse(sanitized.toString().contains("%2520"),
+				"already-encoded ftp path must not be double-encoded: " + sanitized);
+	}
+
+	@Test
+	public void testRegularHttpURLNotTreatedAsJar() throws Exception {
+		// http/https stay on the URIBuilder
+		// normalization path; a "!/" in an http path must not trigger any JAR
+		// special-casing, and host/path must survive the rebuild.
+		URL httpUrl = new URL("http://example.com/a/b!/c.js");
+		URL sanitized = URLs.sanitizeURL(httpUrl);
+
+		assertNotNull(sanitized);
+		assertEquals("http", sanitized.getProtocol());
+		assertEquals("example.com", sanitized.getHost());
+	}
+
+	private static void assertNoEncodedSeparators(URL url) {
+		String s = url.toString();
+		assertFalse(s.contains("%3A"), "URL should not contain encoded ':' (%3A): " + s);
+		assertFalse(s.contains("%21"), "URL should not contain encoded '!' (%21): " + s);
+	}
+}


### PR DESCRIPTION
https://jenkins3.pxinternal.com/view/ZK%20Gradle%20Project%20Daily/job/ZK-Gradle-ZATS-Test/967/
* All failed tests passed locally, except `F104_ZK_4305_DaterangeAttributeTest.testPositionVerticalCenterPlacesPopupInViewport()`, to be fixed by #3597.