### PR TITLE
ZK-6043: Checkmark icons are misaligned/overflowing checkbox containers in a Grid menupopup (mobile)

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -28,6 +28,7 @@ ZK 11.0.0
   ZK-6102: SimpleDesktopCache _cleanup timers are not removed, cause Tomcat errors on application stop
   ZK-6130: Upgrade dependencies to fix security vulnerabilities
   ZK-5751: Combobox without an explicit itemRender mistakenly uses parent's template
+  ZK-6043: Checkmark icons are misaligned/overflowing checkbox containers in a Grid menupopup (mobile)
 
 * Upgrade Notes
   + URLs.sanitizeURL now returns non-http/https URLs unchanged. Applications that call this public API directly should not rely on it to validate or reject container-owned resource URL formats such as jar/wsjar URLs without an entry separator.

--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -40,6 +40,7 @@ ZK 11.0.0
   ZK-6039: $n_ in window setMaximize causes page crashes
   ZK-6060: duplicated attributes in zul.xsd
   ZK-6080: zul.xsd — rowsType Missing groupfoot as Valid Child Element
+  ZK-6043: Checkmark icons are misaligned/overflowing checkbox containers in a Grid menupopup (mobile)
 
 * Upgrade Notes
   + URLs.sanitizeURL now returns non-http/https URLs unchanged. Applications that call this public API directly should not rely on it to validate or reject container-owned resource URL formats such as jar/wsjar URLs without an entry separator.

--- a/zktest/src/main/webapp/test2/B110-ZK-6043.zul
+++ b/zktest/src/main/webapp/test2/B110-ZK-6043.zul
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+B110-ZK-6043.zul
+
+        Purpose:
+
+        Description:
+
+        History:
+                Wed May 06 16:10:02 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+    <label multiline="true">
+        1. Click any column and click dropdown
+        2. The checkmark icon should be perfectly centered within the blue checkbox with sufficient internal padding
+    </label>
+	<grid id="grid">
+		<columns menupopup="auto">
+			<column label="Author" sort="auto"/>
+			<column label="Title" sort="auto"/>
+			<column label="Publisher" sort="auto"/>
+			<column label="Hardcover" sort="auto"/>
+		</columns>
+		<rows>
+			<row>
+				<cell>john</cell>
+				<cell>My journey</cell>
+				<cell>Morning Star</cell>
+				<cell>Yes</cell>
+			</row>
+		</rows>
+	</grid>
+</zk>

--- a/zktest/src/main/webapp/test2/config.properties
+++ b/zktest/src/main/webapp/test2/config.properties
@@ -4514,3 +4514,4 @@ Z60-Touch-042.zul=Z60,A,E,Touch,DragDrop,Scroll,Android,Pad
 ##zats##Z70-ZK-Selector-002.zul=Z70,A,E,ZKSelector,ClientEngine
 ##ztl##Z-Userguide-Form.zul=A,E,InputElement,constraint
 ##ztl##Z-Userguide-Popup.zul=A,E,Popup,tooltip,popup,context
+##zats##B110-ZK-6043.zul=A,M,Grid,Menupopup

--- a/zktest/src/main/webapp/test2/config.properties
+++ b/zktest/src/main/webapp/test2/config.properties
@@ -3307,6 +3307,7 @@ B90-ZK-4431.zul=A,E,Multislider
 ##zats##B110-ZK-6146.zul=A,M,Daterangebox,DaterangePopup,Timebox,showTime
 ##zats##B110-ZK-6060.zul=A,E,zul.xsd
 ##zats##B110-ZK-6080.zul=A,E,Grid,Rows,Groupfoot
+##zats##B110-ZK-6043.zul=A,M,Grid,Menupopup
 
 ##
 # Features - 3.0.x version

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6043Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6043Test.java
@@ -1,0 +1,101 @@
+/* B110_ZK_6043Test.java
+
+        Purpose:
+                
+        Description:
+                
+        History:
+                Wed May 06 16:10:12 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.openqa.selenium.chrome.ChromeOptions;
+
+import org.zkoss.test.webdriver.ExternalZkXml;
+import org.zkoss.test.webdriver.ForkJVMTestOnly;
+import org.zkoss.test.webdriver.WebDriverTestCase;
+
+/**
+ * ZK-6043: in a Grid {@code <columns menupopup="auto">} popup, the checkmark
+ * icons were rendered at the same 24px font-size as the surrounding 24px
+ * blue checkbox container on the tablet UI, so the glyph overflowed and sat
+ * off-centre. The fix shrinks the icon and centres it inside the box.
+ */
+@ForkJVMTestOnly
+public class B110_ZK_6043Test extends WebDriverTestCase {
+	@RegisterExtension
+	public static final ExternalZkXml CONFIG = new ExternalZkXml("/test2/enable-tablet-ui-zk.xml");
+
+	private static final int TOLERANCE_PX = 1;
+
+	@Override
+	protected ChromeOptions getWebDriverOptions() {
+		return super.getWebDriverOptions()
+				.setExperimentalOption("mobileEmulation",
+						Collections.singletonMap("deviceName", "iPad"));
+	}
+
+	@Test
+	public void checkmarkContainedInsideMenuItemImageBox() {
+		connect();
+		waitResponse();
+
+		// Open the column header menupopup so the menuitems exist in the DOM.
+		click(jq(".z-column-button").first());
+		waitResponse();
+
+		assertTrue(jq(".z-menupopup .z-menuitem-icon").exists(),
+				"column auto-menupopup must render menuitem icons");
+
+		// Force every menuitem-icon visible so geometry can be measured even
+		// before the user clicks one (the icon defaults to display:none until
+		// the menuitem becomes checked). Containment of the icon inside its
+		// .z-menuitem-image sibling is what defines "centred in the box".
+		String script
+				= "(function(tol){"
+				+ "var pad='ZK6043_'+Math.random();"
+				+ "var st=document.createElement('style');"
+				+ "st.id=pad;"
+				+ "st.textContent='.z-menupopup .z-menuitem-icon{display:block!important}';"
+				+ "document.head.appendChild(st);"
+				+ "try{"
+				+ "var checkable=document.querySelectorAll('.z-menupopup .z-menuitem-checkable');"
+				+ "if(!checkable.length)return 'no-checkable-items';"
+				+ "var n=0,bad=null;"
+				+ "for(var i=0;i<checkable.length;i++){"
+				+ "  var img=checkable[i].querySelector('.z-menuitem-image');"
+				+ "  var ico=checkable[i].querySelector('.z-menuitem-icon');"
+				+ "  if(!img||!ico)continue;"
+				+ "  var ir=img.getBoundingClientRect();"
+				+ "  var cr=ico.getBoundingClientRect();"
+				+ "  if(ir.width===0||cr.width===0)continue;"
+				+ "  n++;"
+				+ "  if(cr.left<ir.left-tol||cr.top<ir.top-tol"
+				+ "     ||cr.right>ir.right+tol||cr.bottom>ir.bottom+tol){"
+				+ "    bad='icon['+i+'] '+JSON.stringify({"
+				+ "      img:[ir.left,ir.top,ir.right,ir.bottom],"
+				+ "      ico:[cr.left,cr.top,cr.right,cr.bottom]"
+				+ "    });"
+				+ "    break;"
+				+ "  }"
+				+ "}"
+				+ "if(n===0)return 'no-measurable-items';"
+				+ "return bad?'overflow:'+bad:'ok';"
+				+ "}finally{var s=document.getElementById(pad);if(s)s.parentNode.removeChild(s);}"
+				+ "})(" + TOLERANCE_PX + ")";
+		String result = getEval(script);
+		assertEquals("ok", result,
+				"ZK-6043: every menuitem-icon must be contained within its"
+						+ " sibling .z-menuitem-image box (centred checkmark)."
+						+ " Result: " + result);
+	}
+}


### PR DESCRIPTION
Please merge this alongside https://github.com/zkoss/zkcml/pull/1338.