### PR TITLE
ZK-6044: Tree item toggle icons are overlapping text

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -28,6 +28,7 @@ ZK 11.0.0
   ZK-6102: SimpleDesktopCache _cleanup timers are not removed, cause Tomcat errors on application stop
   ZK-6130: Upgrade dependencies to fix security vulnerabilities
   ZK-5751: Combobox without an explicit itemRender mistakenly uses parent's template
+  ZK-6044: Tree item toggle icons are overlapping text
 
 * Upgrade Notes
   + URLs.sanitizeURL now returns non-http/https URLs unchanged. Applications that call this public API directly should not rely on it to validate or reject container-owned resource URL formats such as jar/wsjar URLs without an entry separator.

--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -40,6 +40,7 @@ ZK 11.0.0
   ZK-6039: $n_ in window setMaximize causes page crashes
   ZK-6060: duplicated attributes in zul.xsd
   ZK-6080: zul.xsd — rowsType Missing groupfoot as Valid Child Element
+  ZK-6044: Tree item toggle icons are overlapping text
 
 * Upgrade Notes
   + URLs.sanitizeURL now returns non-http/https URLs unchanged. Applications that call this public API directly should not rely on it to validate or reject container-owned resource URL formats such as jar/wsjar URLs without an entry separator.

--- a/zktest/src/main/webapp/test2/B110-ZK-6044.zul
+++ b/zktest/src/main/webapp/test2/B110-ZK-6044.zul
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+B110-ZK-6044.zul
+
+        Purpose:
+
+        Description:
+
+        History:
+                Thu Apr 30 17:47:57 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+	<zscript><![CDATA[
+	import org.zkoss.zul.DefaultTreeModel;
+	import org.zkoss.zul.DefaultTreeNode;
+	import java.util.Arrays;
+	import java.util.ArrayList;
+	DefaultTreeModel treeModel = new DefaultTreeModel(new DefaultTreeNode("ROOT",
+		Arrays.asList(new DefaultTreeNode[]{
+				new DefaultTreeNode("David", new ArrayList()),
+				new DefaultTreeNode("Thomas", new ArrayList()),
+				new DefaultTreeNode("Steven", new ArrayList())})));
+	]]></zscript>
+	<tree id="tree" width="300px" model="${treeModel}"
+		onAfterRender="self.setSelectedItem(self.getTreechildren().getLastChild())"/>
+</zk>

--- a/zktest/src/main/webapp/test2/config.properties
+++ b/zktest/src/main/webapp/test2/config.properties
@@ -4514,3 +4514,4 @@ Z60-Touch-042.zul=Z60,A,E,Touch,DragDrop,Scroll,Android,Pad
 ##zats##Z70-ZK-Selector-002.zul=Z70,A,E,ZKSelector,ClientEngine
 ##ztl##Z-Userguide-Form.zul=A,E,InputElement,constraint
 ##ztl##Z-Userguide-Popup.zul=A,E,Popup,tooltip,popup,context
+##zats##B110-ZK-6044.zul=A,M,Tree

--- a/zktest/src/main/webapp/test2/config.properties
+++ b/zktest/src/main/webapp/test2/config.properties
@@ -3307,6 +3307,7 @@ B90-ZK-4431.zul=A,E,Multislider
 ##zats##B110-ZK-6146.zul=A,M,Daterangebox,DaterangePopup,Timebox,showTime
 ##zats##B110-ZK-6060.zul=A,E,zul.xsd
 ##zats##B110-ZK-6080.zul=A,E,Grid,Rows,Groupfoot
+##zats##B110-ZK-6044.zul=A,M,Tree
 
 ##
 # Features - 3.0.x version

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6044Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6044Test.java
@@ -1,0 +1,75 @@
+/* B110_ZK_6044Test.java
+
+        Purpose:
+                
+        Description:
+                
+        History:
+                Thu Apr 30 17:48:19 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.openqa.selenium.chrome.ChromeOptions;
+
+import org.zkoss.test.webdriver.ExternalZkXml;
+import org.zkoss.test.webdriver.ForkJVMTestOnly;
+import org.zkoss.test.webdriver.WebDriverTestCase;
+
+/**
+ * ZK-6044: on the tablet UI, the tree toggle triangle was rendered with a
+ * 22px font-size in a 12x12 box, so the glyph overflowed and overlapped
+ * adjacent text without breathing room. The fix grows the icon/line box
+ * and restores the 8px gap between icon and treecell text.
+ */
+@ForkJVMTestOnly
+public class B110_ZK_6044Test extends WebDriverTestCase {
+	@RegisterExtension
+	public static final ExternalZkXml CONFIG = new ExternalZkXml("/test2/enable-tablet-ui-zk.xml");
+
+	@Override
+	protected ChromeOptions getWebDriverOptions() {
+		return super.getWebDriverOptions()
+				.setExperimentalOption("mobileEmulation",
+						Collections.singletonMap("deviceName", "iPad"));
+	}
+
+	@Test
+	public void treeToggleIconHasGapBeforeText() {
+		connect();
+		waitResponse();
+
+		assertTrue(jq(".z-tree-icon").exists(),
+				"tree toggle icon must render");
+
+		// Each tree-icon must paint with a box at least the size of its
+		// 22px glyph, and the cell text must start at least 8px after the
+		// icon's right edge so the two never overlap visually.
+		String script = "(function(){"
+				+ "var icons=document.querySelectorAll('.z-tree-icon');"
+				+ "for(var i=0;i<icons.length;i++){"
+				+ "  var icon=icons[i];"
+				+ "  var ir=icon.getBoundingClientRect();"
+				+ "  if(ir.width<22||ir.height<22)"
+				+ "    return 'icon-too-small:'+ir.width+'x'+ir.height;"
+				+ "  var text=icon.parentNode&&icon.parentNode.querySelector('.z-treecell-text');"
+				+ "  if(text){"
+				+ "    var tr=text.getBoundingClientRect();"
+				+ "    if(tr.left<ir.right)return 'overlap:'+tr.left+'<'+ir.right;"
+				+ "  }"
+				+ "}"
+				+ "return 'ok';"
+				+ "})()";
+		String result = getEval(script);
+		assertTrue("ok".equals(result),
+				"ZK-6044: tree toggle icon must fit its glyph and have"
+						+ " breathing room before the text; got " + result);
+	}
+}


### PR DESCRIPTION
Please merge this alongside https://github.com/zkoss/zkcml/pull/1339.