### PR TITLE
[WIP] ZK-6090: Closing a tab containing <cardlayout> throws "Node is not found" error in mobile/touch simulation mode

### DIFF
--- a/zk/src/main/resources/web/js/zk/domtouch.ts
+++ b/zk/src/main/resources/web/js/zk/domtouch.ts
@@ -155,9 +155,13 @@ zk.override(zk.Widget.prototype, _xWidget, {
 	_pt: [0, 0],
 	_cancelMouseUp: false,
 	_cancelClick: <number | undefined> undefined,
+	_dbTapNode: <HTMLElement | undefined> undefined,
+	_tapHoldNode: <HTMLElement | undefined> undefined,
 	/** @internal */
 	bindSwipe_() {
-		var node = this.$n() as HTMLElement;
+		var node = this.$n() as HTMLElement | undefined;
+		if (!node) //bound without a node of its own, zk.Swipe needs one
+			return;
 		if (this.isListen('onSwipe') || jq(node).data('swipeable'))
 			this._swipe = new zk.Swipe(this, node);
 	},
@@ -166,12 +170,16 @@ zk.override(zk.Widget.prototype, _xWidget, {
 		var swipe = this._swipe;
 		if (swipe) {
 			this._swipe = undefined;
-			swipe.destroy(this.$n() as HTMLElement);
+			//the widget has no node any more, the swipe releases the one it was made of
+			swipe.destroy();
 		}
 	},
 	/** @internal */
 	bindDoubleTap_() {
 		if (this.isListen('onDoubleClick')) {
+			var node = this.$n() as HTMLElement | undefined;
+			if (!node) //bound without a node of its own, there is nothing to listen to
+				return;
 			var doubleClickTime = 500;
 			this._startTap = (wgt: typeof this) => {
 				wgt._lastTap = wgt.$n() as HTMLElement;  //Holds last tapped element (so we can compare for double tap)
@@ -180,16 +188,28 @@ zk.override(zk.Widget.prototype, _xWidget, {
 					wgt._tapValid = false;
 				}, doubleClickTime);
 			};
-			jq(this.$n()).on('touchstart', this.proxy(this._dblTapStart))
+			this._dbTapNode = node;
+			jq(node).on('touchstart', this.proxy(this._dblTapStart))
 				.on('touchend', this.proxy(this._dblTapEnd));
 		}
 	},
 	/** @internal */
 	unbindDoubleTap_() {
-		if (this.isListen('onDoubleClick')) {
+		//gated on the node, not on isListen: the listener may have been removed
+		//since bindDoubleTap_ ran, and the handlers still have to come off
+		var node = this._dbTapNode;
+		if (node) {
 			this._startTap = undefined;
-			jq(this.$n()).off('touchstart', this.proxy(this._dblTapStart))
+			//a pending _tapTimeout would land on the next binding and close its
+			//double-tap window early; _lastTap would also pin the detached node
+			clearTimeout(this._tapTimeout);
+			this._tapTimeout = undefined;
+			this._tapValid = this._dbTap = false;
+			this._lastTap = undefined;
+			//the widget has no node any more, use the one bindDoubleTap_ listened to
+			jq(node).off('touchstart', this.proxy(this._dblTapStart))
 				.off('touchend', this.proxy(this._dblTapEnd));
+			this._dbTapNode = undefined;
 		}
 	},
 	/** @internal */
@@ -229,6 +249,9 @@ zk.override(zk.Widget.prototype, _xWidget, {
 	/** @internal */
 	bindTapHold_() {
 		if (this.isListen('onRightClick') || (window.zul && this instanceof zul.Widget && this.getContext())) { //also register context menu to tapHold event
+			var node = this.$n() as HTMLElement | undefined;
+			if (!node) //bound without a node of its own, there is nothing to listen to
+				return;
 			this._holdTime = 800;
 			this._startHold = (evt: JQuery.TouchEventBase): void => {
 				if (!this._rightClickPending) {
@@ -261,7 +284,8 @@ zk.override(zk.Widget.prototype, _xWidget, {
 					this._holdTimeout = undefined;
 				}
 			};
-			jq(this.$n()).on('touchstart', this.proxy(this._tapHoldStart))
+			this._tapHoldNode = node;
+			jq(node).on('touchstart', this.proxy(this._tapHoldStart))
 				.on('touchmove', this.proxy(this._tapHoldMove)) //cancel hold if moved
 				.on('click', this.proxy(this._tapHoldClick))    //prevent click during hold
 				.on('touchend', this.proxy(this._tapHoldEnd));
@@ -269,12 +293,22 @@ zk.override(zk.Widget.prototype, _xWidget, {
 	},
 	/** @internal */
 	unbindTapHold_() {
-		if (this.isListen('onRightClick') || (window.zul && this instanceof zul.Widget && this.getContext())) { //also register context menu to tapHold event
+		//gated on the node, not on isListen/getContext: either may have gone away
+		//since bindTapHold_ ran, and the handlers still have to come off
+		var node = this._tapHoldNode;
+		if (node) {
+			this._cancelHold?.(); //a hold started before this would fire onRightClick on a dead widget
+			//a hold that already fired leaves these latched: _tapHoldEnd/_tapHoldClick
+			//of the NEXT binding would then swallow its first tap and click
+			this._cancelMouseUp = false;
+			this._cancelClick = undefined;
 			this._startHold = this._cancelHold = undefined;
-			jq(this.$n()).off('touchstart', this.proxy(this._tapHoldStart))
+			//the widget has no node any more, use the one bindTapHold_ listened to
+			jq(node).off('touchstart', this.proxy(this._tapHoldStart))
 				.off('touchmove', this.proxy(this._tapHoldMove)) //cancel hold if moved
 				.off('click', this.proxy(this._tapHoldClick))    //prevent click during hold
 				.off('touchend', this.proxy(this._tapHoldEnd));
+			this._tapHoldNode = undefined;
 		}
 	},
 	/** @internal */

--- a/zk/src/main/resources/web/js/zk/widget.ts
+++ b/zk/src/main/resources/web/js/zk/widget.ts
@@ -800,6 +800,8 @@ export class Widget<TElement extends HTMLElement = HTMLElement> extends zk.Objec
 	declare _norenderdefer;
 	/** @internal */
 	declare _rerendering;
+	/** Handle of the lazy touch-gesture binding timer scheduled by bind_. @internal */
+	declare _gestureTid?: number;
 	declare domExtraAttrs?: Record<string, string>;
 	/** @internal */
 	declare _flexListened;
@@ -3887,10 +3889,22 @@ new zul.wnd.Window({
 
 		if ((zk.mobile || zk.touchEnabled) && after) {
 			after.push(function () {
-				setTimeout(function () {// lazy init
-					self.bindSwipe_();
-					self.bindDoubleTap_();
-					self.bindTapHold_();
+				//one timer per widget: a rebind within the delay would otherwise stack
+				//another, and unbind_ has to be able to cancel it
+				if (self._gestureTid)
+					clearTimeout(self._gestureTid);
+				self._gestureTid = setTimeout(function () {// lazy init
+					self._gestureTid = undefined;
+					if (self.desktop) { //might be unbound
+						//none of the bind*_ is idempotent and a timer from an earlier binding of
+						//this same widget may still be pending, so release before taking a set
+						self.unbindSwipe_();
+						self.unbindDoubleTap_();
+						self.unbindTapHold_();
+						self.bindSwipe_();
+						self.bindDoubleTap_();
+						self.bindTapHold_();
+					}
 				}, 300);
 			});
 		}
@@ -3948,6 +3962,11 @@ new zul.wnd.Window({
 
 		this.unbindChildren_(skipper, after, keepRod);
 		this.cleanDrag_(); //ok to invoke even if not init
+		//the lazy binding timer bind_ scheduled must not outlive this binding
+		if (this._gestureTid) {
+			clearTimeout(this._gestureTid);
+			this._gestureTid = undefined;
+		}
 		this.unbindSwipe_();
 		this.unbindDoubleTap_();
 		this.unbindTapHold_();

--- a/zk/src/main/resources/web/js/zk/zswipe.ts
+++ b/zk/src/main/resources/web/js/zk/zswipe.ts
@@ -80,9 +80,16 @@ export class Swipe extends zk.Object {
 	/**
 	 * Destroys this swipe-able object.
 	 * This method must be called to clean up, if you don't want to associate the swipe-able feature to a DOM element.
+	 * @param node - the DOM element to release. Omit it to release the one this
+	 * swipe was made of, which is what an unbound widget has to do: it no longer
+	 * has a node of its own to hand over.
 	 */
-	destroy(node: HTMLElement): void {
-		jq(node).off(startEvt, this.proxy(this._swipeStart));
+	destroy(node?: HTMLElement): void {
+		//a gesture may be in progress: the move/end handlers would keep running
+		//against the state cleared below
+		jq(node ?? this.node).off(startEvt, this.proxy(this._swipeStart))
+			.off(moveEvt, this.proxy(this._swipeMove))
+			.off(endEvt, this.proxy(this._swipeEnd));
 		this.widget = this.node = this.opts = undefined;
 	}
 
@@ -95,6 +102,10 @@ export class Swipe extends zk.Object {
 			time: evt.timeStamp || Date.now(),
 			coords: [data.pageX, data.pageY]
 		};
+		//start/stop are shared by every Swipe and destroy() takes the end handler off a
+		//gesture in progress: a stale stop would fake an onSwipe on the next plain tap
+		// eslint-disable-next-line no-global-assign
+		stop = undefined;
 		jq(this.node)
 			.on(moveEvt, this.proxy(this._swipeMove) as unknown as false)
 			.one(endEvt, this.proxy(this._swipeEnd) as unknown as false);

--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -40,6 +40,7 @@ ZK 11.0.0
   ZK-6039: $n_ in window setMaximize causes page crashes
   ZK-6060: duplicated attributes in zul.xsd
   ZK-6080: zul.xsd — rowsType Missing groupfoot as Valid Child Element
+  ZK-6090: Closing a tab containing <cardlayout> throws "Node is not found!" error in mobile/touch simulation mode
 
 * Upgrade Notes
   + URLs.sanitizeURL now returns non-http/https URLs unchanged. Applications that call this public API directly should not rely on it to validate or reject container-owned resource URL formats such as jar/wsjar URLs without an entry separator.

--- a/zktest/src/main/webapp/test2/B110-ZK-6090-Bandpopup.zul
+++ b/zktest/src/main/webapp/test2/B110-ZK-6090-Bandpopup.zul
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+B110-ZK-6090-Bandpopup.zul
+
+	Purpose:
+
+	Description:
+
+	History:
+		Thu Aug 20 16:00:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+	<label multiline="true">
+		A bandpopup listens to focusin/focusout on its own node, and has to drop those listeners
+		when it is removed.
+		1. Open the bandbox, type in it, close it again: it behaves as usual.
+		2. Click "detach": the bandbox is gone and it leaves no listener behind.
+	</label>
+
+	<bandbox id="bb" value="x">
+		<bandpopup id="bp" width="200px">
+			<vlayout>
+				<label value="content"/>
+				<textbox id="inner"/>
+			</vlayout>
+		</bandpopup>
+	</bandbox>
+
+	<button id="detach" label="detach" onClick="bb.detach()"/>
+</zk>

--- a/zktest/src/main/webapp/test2/B110-ZK-6090-BindSwipe.zul
+++ b/zktest/src/main/webapp/test2/B110-ZK-6090-BindSwipe.zul
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+B110-ZK-6090-BindSwipe.zul
+
+        Purpose:
+
+        Description:
+
+        History:
+                Thu Aug 20 10:12:31 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+	<label multiline="true">
+		Steps (touch-enabled desktop emulation):
+		1. The page detaches one div 50ms after mount, i.e. inside the 300ms lazy
+		   gesture-init window opened by Widget.bind_.
+		2. No JavaScript error should appear in the browser console.
+		3. "Touch Enabled?" should be true and "Tablet UI?" should be false.
+	</label>
+	Touch Enabled? <label id="touchEnabled"/>
+	Tablet UI? <label id="tabletUI"/>
+	Max Touch Points? <label id="maxTouch"/>
+	<div id="target" width="200px" height="80px" onSwipe='self.setTooltiptext("swiped")'>
+		<label value="detached inside the lazy bindSwipe_ window"/>
+	</div>
+	<div id="keeper" width="200px" height="80px" onSwipe='self.setTooltiptext("swiped")'>
+		<label value="stays bound, must still get its zk.Swipe"/>
+	</div>
+	<slider id="knob" mold="knob" width="120px" height="120px"/>
+	<script><![CDATA[
+	// seq orders the observations against each other, so the test never has to
+	// infer "the detach happened first" from a sleep boundary
+	window.zk6090 = {seq: 0, errors: [], boundBeforeDetach: false, unboundAfterDetach: false,
+		detachSeq: 0, keeperSeq: 0, targetSeq: 0, targetDesktopAtCall: 'not-called'};
+	window.addEventListener('error', function (evt) {
+		window.zk6090.errors.push('' + (evt.message || evt.error));
+	});
+	zk.afterMount(function () {
+		zk.$('$touchEnabled').setValue('' + !!zk.touchEnabled);
+		zk.$('$tabletUI').setValue('' + !!zk.tabletUIEnabled);
+		zk.$('$maxTouch').setValue('' + navigator.maxTouchPoints);
+
+		var target = zk.Widget.$('$target'), keeper = zk.Widget.$('$keeper'),
+			targetBind = target.bindSwipe_, keeperBind = keeper.bindSwipe_;
+		// records every entry into the lazy gesture init, and what desktop looked like
+		target.bindSwipe_ = function () {
+			window.zk6090.targetSeq = ++window.zk6090.seq;
+			window.zk6090.targetDesktopAtCall = '' + !!this.desktop;
+			return targetBind.apply(this, arguments);
+		};
+		// the keeper is never detached, so its call proves the 300ms timers really fired
+		keeper.bindSwipe_ = function () {
+			window.zk6090.keeperSeq = ++window.zk6090.seq;
+			return keeperBind.apply(this, arguments);
+		};
+
+		setTimeout(function () {
+			window.zk6090.boundBeforeDetach = !!target.desktop;
+			window.zk6090.detachSeq = ++window.zk6090.seq;
+			target.detach();
+			window.zk6090.unboundAfterDetach = !target.desktop;
+		}, 50);
+	});
+	]]></script>
+</zk>

--- a/zktest/src/main/webapp/test2/B110-ZK-6090-Coachmark.zul
+++ b/zktest/src/main/webapp/test2/B110-ZK-6090-Coachmark.zul
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+B110-ZK-6090-Coachmark.zul
+
+	Purpose:
+
+	Description:
+
+	History:
+		Thu Aug 21 10:00:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+	<label multiline="true">
+		With the accessibility layer on, a coachmark listens for animationend on its own node so
+		it can move the focus onto the close button once it has slid in. Removing the coachmark
+		has to take exactly that listener off again.
+		1. Click "show": the coachmark appears and the focus lands on its close button.
+		2. Click the close button, then "show" again: the focus still lands on the close button,
+		   and no JS error appears in the console (F12).
+	</label>
+
+	<button id="target" label="Information"/>
+	<coachmark id="cm" target="target" visible="false">
+		<label value="Welcome! click here for more information!"/>
+	</coachmark>
+
+	<button id="show" label="show" onClick="cm.setVisible(!cm.isVisible())"/>
+</zk>

--- a/zktest/src/main/webapp/test2/B110-ZK-6090-ContentHandler.zul
+++ b/zktest/src/main/webapp/test2/B110-ZK-6090-ContentHandler.zul
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?script content="window.zk6090Spy=function(id){var m=zk.Widget.$(id);window['zk6090Hits_'+id]=0;m.onFloatUp=function(){window['zk6090Hits_'+id]++;};return String(!!m._contentHandler);};"?>
+<?script content="window.zk6090Hits=function(id){return String(window['zk6090Hits_'+id]);};"?>
+<?script content="window.zk6090FloatUp=function(){zWatch.fire('onFloatUp', zk.Widget.$('$outside'));};"?>
+<?script content="window.zk6090Unbind=function(id){window['zk6090W_'+id]=zk.Widget.$(id);window['zk6090W_'+id].unbind();};"?>
+<?script content="window.zk6090Bind=function(id){window['zk6090W_'+id].bind();};"?>
+<?script content="window.zk6090GainMenupopup=function(){var m=window.zk6090W_m2=zk.Widget.$('$m2');window.zk6090Pp2=m.$n('cnt-pp');m.menupopup=new zul.menu.Menupopup();m.unbind();return String(!!window.zk6090Pp2);};"?>
+<?script content="window.zk6090Pp2Listeners=function(){var e=jq._data(window.zk6090Pp2,'events')||{},c={mouseenter:0,mouseleave:0,keydown:0};for(var k in e){e[k].forEach(function(h){var t=h.origType||k;if(c[t]!==undefined)c[t]++;});}return [c.mouseenter,c.mouseleave,c.keydown].join(',');};"?>
+<!--
+B110-ZK-6090-ContentHandler.zul
+
+	Purpose:
+
+	Description:
+
+	History:
+		Thu Aug 21 10:00:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+	<label multiline="true">
+		A menu that carries a content (here a colour picker) instead of a menupopup registers
+		itself for the onFloatUp and onHide watches and puts three listeners on its content popup
+		node. Removing the menu has to give all of that back.
+		1. Click "colour": the palette opens. Click somewhere else: it closes again.
+		2. Click "give the second menu a menupopup": the colour content of the second menu is
+		   replaced by an ordinary (empty) menupopup and nothing is left listening.
+	</label>
+
+	<label id="outside" value="a widget outside the menubar, used as the onFloatUp origin"/>
+
+	<menubar id="mb">
+		<menu id="m" label="colour" content="#color=#FF0000"/>
+		<menu id="m2" label="second colour" content="#color=#00FF00"/>
+	</menubar>
+
+	<button id="addPopup" label="give the second menu a menupopup"
+			onClick="m2.appendChild(new org.zkoss.zul.Menupopup())"/>
+</zk>

--- a/zktest/src/main/webapp/test2/B110-ZK-6090-Daterange.zul
+++ b/zktest/src/main/webapp/test2/B110-ZK-6090-Daterange.zul
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?script content="window.zk6090FloatUp=function(){try{zWatch.fire('onFloatUp', zk.Widget.$('$outside'));return 'ok';}catch(e){return 'THROW:'+(e.message||e);}};"?>
+<?script content="window.zk6090UnbindPopup=function(id){var p=window.zk6090Popup=zk.Widget.$(id)._rangePopup;p.unbind();return String(!!p);};"?>
+<?script content="window.zk6090PopupOpen=function(id){return String(!!zk.Widget.$(id)._open);};"?>
+<!--
+B110-ZK-6090-Daterange.zul
+
+	Purpose:
+
+	Description:
+
+	History:
+		Thu Aug 21 10:00:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+	<label multiline="true">
+		An open daterange popup listens for the onFloatUp watch so that clicking anywhere else
+		closes it. Only close() gives that listener back, so a popup that is taken apart while it
+		is still open has to do it itself.
+		1. Open the first box and click the label below it: the popup closes.
+		2. Open it again and click the second box: the first popup closes and the second opens.
+	</label>
+
+	<label id="outside" value="a widget outside both boxes, used as the onFloatUp origin"/>
+
+	<daterangebox id="dr" format="yyyy-MM-dd" width="360px"/>
+	<daterangebox id="drCtrl" format="yyyy-MM-dd" width="360px"/>
+</zk>

--- a/zktest/src/main/webapp/test2/B110-ZK-6090-DocListener.zul
+++ b/zktest/src/main/webapp/test2/B110-ZK-6090-DocListener.zul
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?script content="window.zk6090={errors:[]};window.addEventListener('error',function(evt){window.zk6090.errors.push(''+(evt.message||evt.error));});"?>
+<!--
+B110-ZK-6090-DocListener.zul
+
+	Purpose:
+
+	Description:
+
+	History:
+		Fri Aug 21 14:30:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+-->
+<zk xmlns:ca="client/attribute">
+	<label multiline="true">
+		Each widget below puts a listener on document or window while it is bound. Unbinding it
+		has to take that listener off again, otherwise it keeps running against a widget that is
+		no longer there.
+		1. Unbind the anchornav: the window scroll listener must go.
+		2. Slide the collapsed west region out, then unbind it: the document click listener must go.
+		3. Unbind the dropupload: the document dragenter/dragover listeners must go.
+		4. The second anchornav has a dedicated scroll target, so it watches that target
+		   instead of window. Unbinding either side must take the listener off, and losing
+		   the target must hand the anchornav back to the window fallback.
+	</label>
+
+	<anchornav id="an" name="zk6090anchor">
+		<vlayout>
+			<a id="lnk" ca:data-anchornav-target="$sect">Section</a>
+		</vlayout>
+	</anchornav>
+	<div id="sect" height="40px"><label value="section body"/></div>
+
+	<borderlayout id="bl" height="200px" width="400px">
+		<west id="rgn" size="120px" collapsible="true" open="false" title="west">
+			<label value="west body"/>
+		</west>
+		<center>
+			<label value="center"/>
+		</center>
+	</borderlayout>
+
+	<dropupload id="du" detection="browser" content="drop here"/>
+
+	<anchornav id="an2" name="zk6090scroll">
+		<vlayout>
+			<a id="lnk2" ca:data-anchornav-target="$sect2">Section 2</a>
+		</vlayout>
+	</anchornav>
+	<div id="scroller" ca:data-anchornav-scroll="zk6090scroll" height="80px" width="240px"
+		 style="overflow:auto">
+		<div id="sect2" height="300px"><label value="scrolling body"/></div>
+	</div>
+
+	<script><![CDATA[
+	window.zk6090Count = function (target, type) {
+		var e = jq._data(target == 'window' ? window : document, 'events') || {};
+		return (e[type] || []).length;
+	};
+	window.zk6090Unbind = function (name) {
+		try {
+			window.zk6090[name].unbind();
+		} catch (e) {
+			window.zk6090.errors.push(name + ': ' + (e.message || e));
+		}
+	};
+	window.zk6090CountNode = function (node, type) {
+		var e = jq._data(node, 'events') || {};
+		return (e[type] || []).length;
+	};
+	zk.afterMount(function () {
+		// unbind() drops the widgets from zk.Widget.$, so hold on to them first
+		window.zk6090.an = zk.Widget.$('$an');
+		window.zk6090.rgn = zk.Widget.$('$rgn');
+		window.zk6090.du = zk.Widget.$('$du');
+		window.zk6090.an2 = zk.Widget.$('$an2');
+		window.zk6090.scroller = zk.Widget.$('$scroller');
+		// the scroll listener goes on the cave node, which is what has to be cleaned
+		window.zk6090.scrollerCave = window.zk6090.scroller.getCaveNode();
+	});
+	]]></script>
+</zk>

--- a/zktest/src/main/webapp/test2/B110-ZK-6090-DomTouch.zul
+++ b/zktest/src/main/webapp/test2/B110-ZK-6090-DomTouch.zul
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?script content="window.zk6090Errors=[];window.addEventListener('error',function(evt){if(!evt.message)return;window.zk6090Errors.push(evt.message);var b=document.getElementById('zk6090-errors');if(!b){b=document.createElement('pre');b.id='zk6090-errors';b.style.color='red';document.body.appendChild(b);}b.textContent='errors: '+window.zk6090Errors.length+' | '+window.zk6090Errors.join(' | ');});"?>
+<!--
+B110-ZK-6090-DomTouch.zul
+
+	Purpose:
+
+	Description:
+
+	History:
+		Thu Aug 20 16:00:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+	<label multiline="true">
+		On a touch device a widget listening to onSwipe, onDoubleClick or onRightClick gets
+		touch listeners on its own node, and those have to go away with the widget.
+		1. Open this page on a touch device (or with touch emulation on).
+		2. Click "detach": the box is gone and it leaves no touch listener behind.
+	</label>
+
+	<div id="d" width="120px" height="80px" style="border:1px solid #888"
+		 onSwipe="self.setStyle('border:1px solid #888')"
+		 onDoubleClick="self.setStyle('border:1px solid #888')"
+		 onRightClick="self.setStyle('border:1px solid #888')">touch me</div>
+
+	<button id="detach" label="detach" onClick="d.detach()"/>
+</zk>

--- a/zktest/src/main/webapp/test2/B110-ZK-6090-Frozen.zul
+++ b/zktest/src/main/webapp/test2/B110-ZK-6090-Frozen.zul
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?script content="window.zk6090Errors=[];window.addEventListener('error',function(evt){if(!evt.message)return;window.zk6090Errors.push(evt.message);var b=document.getElementById('zk6090-errors');if(!b){b=document.createElement('pre');b.id='zk6090-errors';b.style.color='red';document.body.appendChild(b);}b.textContent='errors: '+window.zk6090Errors.length+' | '+window.zk6090Errors.join(' | ');});"?>
+<?script content="window.zk6090DropFrozen=function(){var f=zk.Widget.$('$fz');f.onSize();f.unbind();};"?>
+<!--
+B110-ZK-6090-Frozen.zul
+
+	Purpose:
+
+	Description:
+
+	History:
+		Thu Aug 20 17:30:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+	<!-- the smooth mold is an EE replacement of onSize; this page is about the CE one -->
+	<custom-attributes org.zkoss.zul.frozen.smooth="false"/>
+	<label multiline="true">
+		A frozen column finishes its sizing in a timer, so a frozen that goes away before the timer
+		fires must take the timer with it.
+		1. Click "size and drop the frozen": the first grid sizes its frozen column and drops it
+		   while onSize is still running. There should be no JS error in the console (F12).
+		2. The control grid keeps its frozen: click "resize the control" and it still scrolls
+		   sideways with the arrows.
+	</label>
+
+	<label value="1. the frozen goes away between onSize and its timer"/>
+	<grid id="g" width="300px">
+		<columns>
+			<column label="a"/>
+			<column label="b"/>
+			<column label="c"/>
+			<column label="d"/>
+			<column label="e"/>
+			<column label="f"/>
+		</columns>
+		<frozen id="fz" columns="2"/>
+		<rows>
+			<row>
+				<label value="1"/><label value="2"/><label value="3"/>
+				<label value="4"/><label value="5"/><label value="6"/>
+			</row>
+		</rows>
+	</grid>
+	<button id="drop" label="size and drop the frozen"
+			onClick='Clients.evalJavaScript("zk6090DropFrozen();")'/>
+
+	<separator/>
+	<label value="2. control: the frozen stays"/>
+	<grid id="gCtrl" width="300px">
+		<columns>
+			<column label="a"/>
+			<column label="b"/>
+			<column label="c"/>
+			<column label="d"/>
+			<column label="e"/>
+			<column label="f"/>
+		</columns>
+		<frozen id="fzCtrl" columns="2"/>
+		<rows>
+			<row>
+				<label value="1"/><label value="2"/><label value="3"/>
+				<label value="4"/><label value="5"/><label value="6"/>
+			</row>
+		</rows>
+	</grid>
+	<button id="dropCtrl" label="resize the control" onClick="Clients.resize(gCtrl)"/>
+</zk>

--- a/zktest/src/main/webapp/test2/B110-ZK-6090-FrozenSmooth.zul
+++ b/zktest/src/main/webapp/test2/B110-ZK-6090-FrozenSmooth.zul
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?script content="window.zk6090Errors=[];window.addEventListener('error',function(evt){if(!evt.message)return;window.zk6090Errors.push(evt.message);var b=document.getElementById('zk6090-errors');if(!b){b=document.createElement('pre');b.id='zk6090-errors';b.style.color='red';document.body.appendChild(b);}b.textContent='errors: '+window.zk6090Errors.length+' | '+window.zk6090Errors.join(' | ');});"?>
+<?script content="window.zk6090DropSmoothFrozen=function(){var f=zk.Widget.$('$fz');f.onSize();f.unbind();};"?>
+<!--
+B110-ZK-6090-FrozenSmooth.zul
+
+	Purpose:
+
+	Description:
+
+	History:
+		Thu Aug 21 10:00:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+	<label multiline="true">
+		The smooth frozen column (the default) replaces onSize with its own version, which also
+		finishes its sizing in a timer. A frozen that goes away before the timer fires must take
+		the timer with it.
+		1. Click "size and drop the frozen": the first grid sizes its frozen column and drops it
+		   while onSize is still running. There should be no JS error in the console (F12).
+		2. The control grid keeps its frozen: click "resize the control" and it still scrolls
+		   sideways.
+	</label>
+
+	<label value="1. the frozen goes away between onSize and its timer"/>
+	<grid id="g" width="300px">
+		<columns>
+			<column label="a"/>
+			<column label="b"/>
+			<column label="c"/>
+			<column label="d"/>
+			<column label="e"/>
+			<column label="f"/>
+		</columns>
+		<frozen id="fz" columns="2"/>
+		<rows>
+			<row>
+				<label value="1"/><label value="2"/><label value="3"/>
+				<label value="4"/><label value="5"/><label value="6"/>
+			</row>
+		</rows>
+	</grid>
+	<button id="drop" label="size and drop the frozen"
+			onClick='Clients.evalJavaScript("zk6090DropSmoothFrozen();")'/>
+
+	<separator/>
+	<label value="2. control: the frozen stays"/>
+	<grid id="gCtrl" width="300px">
+		<columns>
+			<column label="a"/>
+			<column label="b"/>
+			<column label="c"/>
+			<column label="d"/>
+			<column label="e"/>
+			<column label="f"/>
+		</columns>
+		<frozen id="fzCtrl" columns="2"/>
+		<rows>
+			<row>
+				<label value="1"/><label value="2"/><label value="3"/>
+				<label value="4"/><label value="5"/><label value="6"/>
+			</row>
+		</rows>
+	</grid>
+	<button id="dropCtrl" label="resize the control" onClick="Clients.resize(gCtrl)"/>
+</zk>

--- a/zktest/src/main/webapp/test2/B110-ZK-6090-KnobSlider.zul
+++ b/zktest/src/main/webapp/test2/B110-ZK-6090-KnobSlider.zul
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?script content="window.zk6090={errors:[]};window.addEventListener('error',function(evt){window.zk6090.errors.push(''+(evt.message||evt.error));});"?>
+<!--
+B110-ZK-6090-KnobSlider.zul
+
+	Purpose:
+
+	Description:
+
+	History:
+		Fri Aug 21 11:40:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+	<label multiline="true">
+		Steps:
+		1. Unbind the knob slider: the wheel and focus handlers its knob mold added must
+		   come off, and the knob Draggable must be released.
+		2. Switch the knob slider to another mold: the same teardown must happen, even
+		   though setMold() changes the mold before it redraws.
+	</label>
+
+	<slider id="knob" mold="knob" width="150px" height="150px"/>
+	<!-- so the client also has the plain mold loaded, for the mold switch below -->
+	<slider id="plain" width="200px"/>
+	<button id="dummy" label="keeps the page interactive"/>
+
+	<script><![CDATA[
+	window.zk6090Count = function (node, type) {
+		var e = jq._data(node, 'events') || {};
+		return (e[type] || []).length;
+	};
+	// wheel handlers on the input and the svg, then the a11y focus handlers on the input
+	window.zk6090Handlers = function () {
+		var s = window.zk6090;
+		return [window.zk6090Count(s.inputNode, 'mousewheel'),
+			window.zk6090Count(s.svgNode, 'mousewheel'),
+			window.zk6090Count(s.inputNode, 'focusin'),
+			window.zk6090Count(s.inputNode, 'focusout')].join(',');
+	};
+	zk.afterMount(function () {
+		var knob = zk.Widget.$('$knob');
+		// unbind() drops the widget from zk.Widget.$, and the mold switch throws its
+		// nodes away, so both are captured while they are still reachable
+		window.zk6090.knob = knob;
+		window.zk6090.inputNode = knob.$n('input');
+		window.zk6090.svgNode = knob.$n('knob-svg');
+		window.zk6090.plain = zk.Widget.$('$plain');
+	});
+	]]></script>
+</zk>

--- a/zktest/src/main/webapp/test2/B110-ZK-6090-Nav.zul
+++ b/zktest/src/main/webapp/test2/B110-ZK-6090-Nav.zul
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?script content="window.zk6090NavOpen=function(){var nav=zk.Widget.$('$nv');window.zk6090NavUuid=nav.uuid;nav._doMouseEnter();return String(!!nav._isPopup);};"?>
+<?script content="window.zk6090NavAtBody=function(){var n=document.getElementById(window.zk6090NavUuid+'-text');if(!n)return 'false';return String(n.parentNode===document.body);};"?>
+<?script content="window.zk6090NavLeaveAndDrop=function(){var nav=zk.Widget.$('$nv');nav._doMouseLeave();nav.parent.removeChild(nav);};"?>
+<?script content="window.zk6090NavStrays=function(){var u=window.zk6090NavUuid,r=[];['text','cave'].forEach(function(s){if(document.getElementById(u+'-'+s))r.push(s);});return r.join(',');};"?>
+<?script content="window.zk6090NavCtrlOpen=function(){var nav=zk.Widget.$('$nvCtrl');nav._doMouseEnter();return String(!!nav._isPopup);};"?>
+<?script content="window.zk6090NavCtrlLeave=function(){zk.Widget.$('$nvCtrl')._doMouseLeave();};"?>
+<?script content="window.zk6090NavCtrlPopup=function(){var nav=zk.Widget.$('$nvCtrl');return String(!!nav._isPopup)+','+String(nav.$n('text').parentNode===document.body);};"?>
+<!--
+B110-ZK-6090-Nav.zul
+
+	Purpose:
+
+	Description:
+
+	History:
+		Thu Aug 21 10:00:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+	<label multiline="true">
+		A collapsed navbar pops its nav out by moving the -text and -cave nodes to document.body,
+		and closes it again 100ms after the mouse leaves. A nav that goes away inside that 100ms
+		must still put both nodes back, or they are left in the page for good.
+		1. Hover "dropped": the sub menu pops out beside the navbar.
+		2. Click "leave and drop the nav" (it leaves the nav and removes it in the same task):
+		   the popup must disappear with it. Nothing may be left over at the bottom of the page.
+		3. Control: hover "control" and move away; the popup closes after 100ms as usual.
+	</label>
+
+	<navbar id="nb" orient="vertical" collapsed="true" hflex="min">
+		<nav id="nv" label="dropped" iconSclass="z-icon-cogs">
+			<navitem label="one"/>
+			<navitem label="two"/>
+		</nav>
+		<nav id="nvCtrl" label="control" iconSclass="z-icon-cogs">
+			<navitem label="three"/>
+		</nav>
+	</navbar>
+
+	<button id="pop" label="pop the nav out" onClick='Clients.evalJavaScript("zk6090NavOpen()")'/>
+	<button id="drop" label="leave and drop the nav" onClick='Clients.evalJavaScript("zk6090NavLeaveAndDrop()")'/>
+</zk>

--- a/zktest/src/main/webapp/test2/B110-ZK-6090-NavitemPopup.zul
+++ b/zktest/src/main/webapp/test2/B110-ZK-6090-NavitemPopup.zul
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?script content="window.zk6090={errors:[]};window.addEventListener('error',function(evt){window.zk6090.errors.push(''+(evt.message||evt.error));});"?>
+<!--
+B110-ZK-6090-NavitemPopup.zul
+
+	Purpose:
+
+	Description:
+
+	History:
+		Fri Aug 21 14:10:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+	<label multiline="true">
+		A topmost navitem of a collapsed navbar pops its label out into document.body while the
+		pointer is over it, and closes it again 100ms after the pointer leaves.
+		1. Hover the item, move the pointer away, and let the page unbind the item within
+		   those 100ms.
+		2. The popped-out label must come back with the item, and no JS error may appear.
+	</label>
+
+	<navbar id="nb" collapsed="true" orient="vertical" width="60px">
+		<navitem id="ni" label="Reports" iconSclass="z-icon-cogs"/>
+	</navbar>
+
+	<script><![CDATA[
+	// the popup label is moved to document.body; that is what has to be undone
+	window.zk6090Orphaned = function () {
+		var text = window.zk6090.textNode;
+		return '' + !!(text && text.parentNode === document.body);
+	};
+	window.zk6090Unbind = function () {
+		try {
+			window.zk6090.ni.unbind();
+		} catch (e) {
+			window.zk6090.errors.push('unbind: ' + (e.message || e));
+		}
+	};
+	zk.afterMount(function () {
+		var ni = zk.Widget.$('$ni');
+		// unbind() drops the widget from zk.Widget.$, so hold on to both first
+		window.zk6090.ni = ni;
+		window.zk6090.textNode = ni.$n('text');
+	});
+	]]></script>
+</zk>

--- a/zktest/src/main/webapp/test2/B110-ZK-6090-RebindGesture.zul
+++ b/zktest/src/main/webapp/test2/B110-ZK-6090-RebindGesture.zul
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?script content="window.zk6090RG={};window.zk6090RG.count=function(t){var n=zk.Widget.$('$target').$n(),e=(n&&jq._data(n,'events'))||{};return String((e[t]||[]).length);};"?>
+<?script content="window.zk6090RG.bound=0;window.zk6090RG.rebound=false;zk.afterMount(function(){setTimeout(function(){window.zk6090RG.rebound=true;zk.Widget.$('$target').rerender();},50);});"?>
+<!--
+B110-ZK-6090-RebindGesture.zul
+
+	Purpose:
+
+	Description:
+
+	History:
+		Mon Sep 01 14:00:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+	<label multiline="true">
+		Steps (touch-enabled desktop emulation):
+		1. Widget.bind_ schedules the swipe/double-tap/tap-hold binding 300ms later, and none of
+		   those three bind methods is idempotent.
+		2. The div below is rerendered 50ms after it is mounted, so the same widget instance is
+		   unbound and bound again while the first timer is still pending.
+		3. Only one set of gesture handlers may end up on the node. Two sets make a single tap
+		   report itself as a double click.
+	</label>
+	Touch Enabled? <label id="touchEnabled"/>
+	tapped onDoubleClick: <label id="dblLog"/>
+
+	<div id="target" width="200px" height="80px"
+			onDoubleClick='dblLog.setValue(dblLog.getValue() + "D")'
+			onSwipe='dblLog.setValue(dblLog.getValue() + "S")'>
+		<label value="rerendered 50ms after mount"/>
+	</div>
+
+	<zscript><![CDATA[
+		touchEnabled.setValue("");
+	]]></zscript>
+	<?script content="zk.afterMount(function(){zk.Widget.$('$touchEnabled').setValue(String(!!zk.touchEnabled));});"?>
+</zk>

--- a/zktest/src/main/webapp/test2/B110-ZK-6090-SlideRebind.zul
+++ b/zktest/src/main/webapp/test2/B110-ZK-6090-SlideRebind.zul
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?script content="window.zk6090Errors=[];window.addEventListener('error',function(evt){if(!evt.message)return;window.zk6090Errors.push(evt.message);var b=document.getElementById('zk6090-errors');if(!b){b=document.createElement('pre');b.id='zk6090-errors';b.style.color='red';document.body.appendChild(b);}b.textContent='errors: '+window.zk6090Errors.length+' | '+window.zk6090Errors.join(' | ');});window.zk6090SlideFlags=function(){var r=zk.Widget.$('$w');return r._isSlide+','+r._slide;};window.zk6090SlideShown=function(){var n=zk.Widget.$('$w').$n('real');if(!n)return false;return n.offsetWidth>0?n.offsetHeight>0:false;};window.zk6090Rerender=function(){zk.Widget.$('$w').rerender(-1);};"?>
+<!--
+B110-ZK-6090-SlideRebind.zul
+
+	Purpose:
+
+	Description:
+
+	History:
+		Thu Sep 03 16:00:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+-->
+<zk xmlns:w="client">
+	<label multiline="true">
+		A collapsed region that is slid down carries that state on the widget, not in the DOM, so a
+		rerender draws it collapsed again while the state still says it is slid down.
+		1. Click the "W" title of the collapsed region. It slides down.
+		2. Click "rerender this region" inside it. The region is drawn collapsed again.
+		3. Click the "W" title once. It must slide down again on that first click, and there should
+		   be no JS error in the console (F12).
+	</label>
+
+	<borderlayout id="bl" height="200px" width="420px">
+		<west id="w" title="W" collapsible="true" open="false" size="160px">
+			<vlayout>
+				<label value="slid down"/>
+				<!-- inside -real, so the click does not slide the region up first;
+					deferred a tick because the rerender replaces this button too -->
+				<button id="rerender" label="rerender this region"
+						w:onClick="setTimeout(zk6090Rerender, 0);"/>
+			</vlayout>
+		</west>
+		<center border="none">
+			<label value="center"/>
+		</center>
+	</borderlayout>
+</zk>

--- a/zktest/src/main/webapp/test2/B110-ZK-6090-Spinner.zul
+++ b/zktest/src/main/webapp/test2/B110-ZK-6090-Spinner.zul
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?script content="window.zk6090Errors=[];window.addEventListener('error',function(evt){if(!evt.message)return;window.zk6090Errors.push(evt.message);var b=document.getElementById('zk6090-errors');if(!b){b=document.createElement('pre');b.id='zk6090-errors';b.style.color='red';document.body.appendChild(b);}b.textContent='errors: '+window.zk6090Errors.length+' | '+window.zk6090Errors.join(' | ');});"?>
+<!--
+B110-ZK-6090-Spinner.zul
+
+	Purpose:
+
+	Description:
+
+	History:
+		Thu Aug 20 16:00:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+	<label multiline="true">
+		A spinner watches the whole document for the mouse button going up, so it has to stop
+		watching when it is removed. Doublespinner and Timebox share the same arrows.
+		1. Press and hold an up arrow. onChanging closes that window right away.
+		2. Release the mouse button. There should be no JS error in the console (F12).
+	</label>
+
+	<window id="w" title="hold the up arrow" width="300px" border="normal">
+		<spinner id="sp" value="1" onChanging="w.detach()"/>
+	</window>
+
+	<label value="control (stays on the page):"/>
+	<spinner id="spCtrl" value="1"/>
+
+	<separator/>
+	<window id="w2" title="hold the up arrow" width="300px" border="normal">
+		<doublespinner id="dsp" value="1" onChanging="w2.detach()"/>
+	</window>
+
+	<label value="control (stays on the page):"/>
+	<doublespinner id="dspCtrl" value="1"/>
+
+	<separator/>
+	<window id="w3" title="hold the up arrow" width="300px" border="normal">
+		<timebox id="tb" onChanging="w3.detach()"/>
+	</window>
+
+	<label value="control (stays on the page):"/>
+	<timebox id="tbCtrl"/>
+</zk>

--- a/zktest/src/main/webapp/test2/B110-ZK-6090-SwipeState.zul
+++ b/zktest/src/main/webapp/test2/B110-ZK-6090-SwipeState.zul
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+B110-ZK-6090-SwipeState.zul
+
+	Purpose:
+
+	Description:
+
+	History:
+		Fri Aug 28 10:20:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+	<label multiline="true">
+		Steps (touch-enabled desktop emulation):
+		1. Both divs listen to onSwipe, so each of them gets its own zk.Swipe, and
+		   every zk.Swipe shares the same start/stop of the gesture in progress.
+		2. A gesture is started on the first div and the div is unbound before the
+		   gesture ends, so that gesture is never consumed.
+		3. A plain tap on the second div, without any movement at all, must not be
+		   reported as a swipe.
+	</label>
+	Touch Enabled? <label id="touchEnabled"/>
+	aborted onSwipe: <label id="abortedLog"/>
+	tapped onSwipe: <label id="tappedLog"/>
+	<div id="aborted" width="200px" height="80px" onSwipe='abortedLog.setValue(abortedLog.getValue() + "A")'>
+		<label value="the gesture starts here and is unbound before it ends"/>
+	</div>
+	<div id="tapped" width="200px" height="80px" onSwipe='tappedLog.setValue(tappedLog.getValue() + "B")'>
+		<label value="only tapped, must never be swiped"/>
+	</div>
+	<script><![CDATA[
+	window.zk6090s = {
+		errors: [], abortedSwipes: 0, tappedSwipes: 0,
+		hastouch: 'ontouchstart' in window,
+		// without these the gesture below would not be a touch gesture at all, and the
+		// test has to fail loudly instead of silently testing nothing
+		canSynth: typeof TouchEvent == 'function' && typeof Touch == 'function'
+	};
+	window.addEventListener('error', function (evt) {
+		window.zk6090s.errors.push('' + (evt.message || evt.error));
+	});
+	(function () {
+		var S = window.zk6090s;
+		function evtName(kind) {
+			if (S.hastouch)
+				return kind == 'start' ? 'touchstart' : kind == 'move' ? 'touchmove' : 'touchend';
+			return kind == 'start' ? 'mousedown' : kind == 'move' ? 'mousemove' : 'mouseup';
+		}
+		// dispatched straight at the node zk.Swipe bound its handlers to, and not
+		// bubbling, so the simulated gesture cannot leak into the rest of the page
+		function fire(node, kind, x, y) {
+			var type = evtName(kind), evt;
+			if (S.hastouch) {
+				var touch = new Touch({identifier: 1, target: node, clientX: x, clientY: y,
+						pageX: x, pageY: y, screenX: x, screenY: y}),
+					live = kind == 'end' ? [] : [touch];
+				evt = new TouchEvent(type, {touches: live, targetTouches: live,
+					changedTouches: [touch], bubbles: false, cancelable: true, view: window});
+			} else
+				evt = new MouseEvent(type, {clientX: x, clientY: y, bubbles: false,
+					cancelable: true, view: window});
+			node.dispatchEvent(evt);
+		}
+		S.swipe = function (id) {
+			fire(S[id].node, 'start', 100, 100);
+			fire(S[id].node, 'move', 160, 100);
+			fire(S[id].node, 'end', 160, 100);
+		};
+		S.gestureWithoutEnd = function (id) {
+			fire(S[id].node, 'start', 100, 100);
+			fire(S[id].node, 'move', 160, 100);
+		};
+		// far enough from the coordinates above that the stale ones would be read as a
+		// swipe, so a passing test really means the state was dropped
+		S.tap = function (id) {
+			fire(S[id].node, 'start', 300, 300);
+			fire(S[id].node, 'end', 300, 300);
+		};
+		S.hasSwipe = function (id) {
+			return '' + !!S[id].wgt._swipe;
+		};
+		// the .one(touchend) zk.Swipe adds per gesture; 0 after destroy() means
+		// _swipeEnd can never run again and the gesture state is stranded
+		S.endHandlers = function (id) {
+			var e = jq._data(S[id].node, 'events') || {};
+			return '' + ((e[evtName('end')] || []).length);
+		};
+		S.unbind = function (id) {
+			try {
+				S[id].wgt.unbind();
+			} catch (e) {
+				S.errors.push(id + ': ' + (e.message || e));
+			}
+		};
+		zk.afterMount(function () {
+			zk.$('$touchEnabled').setValue('' + !!zk.touchEnabled);
+			['aborted', 'tapped'].forEach(function (id) {
+				// unbind() drops the widget from zk.Widget.$ and clears its node cache
+				var wgt = zk.Widget.$('$' + id), orig = wgt.doSwipe_;
+				S[id] = {wgt: wgt, node: wgt.$n()};
+				wgt.doSwipe_ = function (evt) {
+					S[id + 'Swipes']++;
+					return orig.apply(this, arguments);
+				};
+			});
+		});
+	})();
+	]]></script>
+</zk>

--- a/zktest/src/main/webapp/test2/B110-ZK-6090-TabboxMold.zul
+++ b/zktest/src/main/webapp/test2/B110-ZK-6090-TabboxMold.zul
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?script content="window.zk6090={errors:[]};window.addEventListener('error',function(evt){window.zk6090.errors.push(''+(evt.message||evt.error));});"?>
+<!--
+B110-ZK-6090-TabboxMold.zul
+
+	Purpose:
+
+	Description:
+
+	History:
+		Tue Sep 09 10:20:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+	<label multiline="true">
+		Steps (mobile/touch emulation with the tablet UI on):
+		1. Push a new mold onto the first tabbox from the server.
+		2. The tablet augment only knows "default" and "accordion" and maps the pushed
+		   mold onto one of them, but it still has to redraw: only the accordion mold
+		   draws a -cave2 node inside a tabpanel, so a mold that is assigned without a
+		   redraw leaves the DOM contradicting the mold, and getCaveNode() then finds
+		   nothing.
+	</label>
+	Tablet UI? <label id="tabletUI"/>
+	Touch? <label id="touch"/>
+
+	<tabbox id="tbx" width="400px" height="160px">
+		<tabs>
+			<tab label="one"/>
+			<tab label="two"/>
+		</tabs>
+		<tabpanels>
+			<tabpanel id="tp1">
+				<label value="panel one"/>
+			</tabpanel>
+			<tabpanel id="tp2">
+				<label value="panel two"/>
+			</tabpanel>
+		</tabpanels>
+	</tabbox>
+
+	<!-- so the client also has the accordion mold loaded, for the mold pushes below -->
+	<tabbox id="accd" mold="accordion" width="400px" height="160px">
+		<tabs>
+			<tab label="already accordion"/>
+		</tabs>
+		<tabpanels>
+			<tabpanel>
+				<label value="panel"/>
+			</tabpanel>
+		</tabpanels>
+	</tabbox>
+
+	<button id="toAccordion" label="server: setMold(accordion)" onClick='tbx.setMold("accordion")'/>
+	<button id="toDefault" label="server: setMold(default)" onClick='tbx.setMold("default")'/>
+	<button id="toAccordionLite" label="server: setMold(accordion-lite)" onClick='tbx.setMold("accordion-lite")'/>
+
+	<script><![CDATA[
+	// The accordion mold is the only one that wraps a tabpanel's cave in a -cave2, so it
+	// tells a redrawn tabbox from one whose DOM still belongs to the previous mold.
+	// Everything is looked up again on each call: rerender() throws the old nodes away.
+	window.zk6090Dom = function () {
+		var tbx = zk.Widget.$('$tbx'),
+			tp = zk.Widget.$('$tp1');
+		return [tbx.getMold(),
+			jq(tbx.$n()).hasClass(tbx.$s('accordion')) ? 'accordion' : 'plain',
+			tp.$n('cave2') ? 'cave2' : 'no-cave2',
+			tp.getCaveNode() ? 'cave' : 'no-cave'].join(',');
+	};
+	zk.afterMount(function () {
+		zk.$('$tabletUI').setValue('' + !!zk.tabletUIEnabled);
+		zk.$('$touch').setValue('' + !!zk.touchEnabled);
+	});
+	]]></script>
+</zk>

--- a/zktest/src/main/webapp/test2/B110-ZK-6090-Teardown.zul
+++ b/zktest/src/main/webapp/test2/B110-ZK-6090-Teardown.zul
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?script content="window.zk6090={errors:[]};window.addEventListener('error',function(evt){window.zk6090.errors.push(''+(evt.message||evt.error));});"?>
+<!--
+B110-ZK-6090-Teardown.zul
+
+	Purpose:
+
+	Description:
+
+	History:
+		Fri Aug 21 14:50:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+	<label multiline="true">
+		1. Unbind the biglistbox: the wheel handlers its fake scrollbars put on the body node
+		   must come off, the body node itself stays.
+		2. Open the goldenlayout tab dropdown, then unbind the layout: the dropdown container
+		   must not be left behind in document.body.
+	</label>
+
+	<zscript><![CDATA[
+	class Zk6090MatrixModel extends AbstractListModel implements MatrixModel {
+		List rows = new ArrayList();
+		public void add(Object item) {
+			rows.add(item);
+		}
+		public Object getElementAt(int index) {
+			return rows.get(index);
+		}
+		public int getSize() {
+			return rows.size();
+		}
+		public int getColumnSize() {
+			return 4;
+		}
+		public int getHeadSize() {
+			return 1;
+		}
+		public Object getHeadAt(int rowIndex) {
+			return "Head" + rowIndex;
+		}
+		public Object getCellAt(Object rowData, int columnIndex) {
+			return rowData + "-" + columnIndex;
+		}
+		public Object getHeaderAt(Object headData, int columnIndex) {
+			return headData + ":" + columnIndex;
+		}
+	}
+	Zk6090MatrixModel model = new Zk6090MatrixModel();
+	for (int i = 0; i < 30; i++) {
+		model.add("row" + i);
+	}
+	]]></zscript>
+
+	<biglistbox id="blb" model="${model}" colWidth="120px" width="300px" height="150px">
+		<template name="rows">
+			<html><attribute name="content"><![CDATA[<span>${each}</span>]]></attribute></html>
+		</template>
+	</biglistbox>
+
+	<goldenlayout id="gl" width="260px" height="160px">
+		<goldenpanel title="Panel one"><label value="one"/></goldenpanel>
+		<goldenpanel title="Panel two"><label value="two"/></goldenpanel>
+		<goldenpanel title="Panel three"><label value="three"/></goldenpanel>
+		<goldenpanel title="Panel four"><label value="four"/></goldenpanel>
+		<goldenpanel title="Panel five"><label value="five"/></goldenpanel>
+	</goldenlayout>
+
+	<script><![CDATA[
+	window.zk6090Events = function (node) {
+		var e = jq._data(node, 'events') || {}, out = [];
+		for (var k in e) out.push(k + ':' + e[k].length);
+		return out.sort().join(',');
+	};
+	window.zk6090Wheel = function () {
+		var e = jq._data(window.zk6090.bodyNode, 'events') || {};
+		return '' + ((e.mousewheel || []).length + (e.wheel || []).length);
+	};
+	// the tab dropdown container is moved to document.body while it is open
+	window.zk6090DropdownOrphans = function () {
+		return '' + jq(document.body).children('.lm_tabdropdown_list').length;
+	};
+	window.zk6090Unbind = function (name) {
+		try {
+			window.zk6090[name].unbind();
+		} catch (e) {
+			window.zk6090.errors.push(name + ': ' + (e.message || e));
+		}
+	};
+	zk.afterMount(function () {
+		var blb = zk.Widget.$('$blb');
+		// unbind() drops the widgets from zk.Widget.$, so hold on to them first
+		window.zk6090.blb = blb;
+		window.zk6090.bodyNode = blb.$n('body');
+		window.zk6090.gl = zk.Widget.$('$gl');
+	});
+	]]></script>
+</zk>

--- a/zktest/src/main/webapp/test2/B110-ZK-6090-Timer.zul
+++ b/zktest/src/main/webapp/test2/B110-ZK-6090-Timer.zul
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+B110-ZK-6090-Timer.zul
+
+	Purpose:
+
+	Description:
+
+	History:
+		Fri Aug 28 10:20:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+	<label multiline="true">
+		Steps:
+		1. A repeating timer registers a zAu error handler every time it plays, and
+		   must take that very handler off again every time it stops.
+		2. The timer starts stopped, so nothing is registered yet.
+		3. Toggling running off and on a few times must leave exactly one handler
+		   behind, not one per cycle.
+	</label>
+	<timer id="tm" delay="100000" repeats="true" running="false"/>
+	<script><![CDATA[
+	window.zk6090tm = {calls: 0, errors: [], patched: false};
+	window.addEventListener('error', function (evt) {
+		window.zk6090tm.errors.push('' + (evt.message || evt.error));
+	});
+	zk.afterMount(function () {
+		// the timer is not running yet, so no handler has been registered from the
+		// unpatched method and every later registration goes through the counter
+		var proto = zul.utl.Timer.prototype, orig = proto._onErr;
+		proto._onErr = function () {
+			window.zk6090tm.calls++;
+			return orig.apply(this, arguments);
+		};
+		window.zk6090tm.patched = true;
+	});
+	window.zk6090tm.cycle = function (times) {
+		var wgt = zk.Widget.$('$tm');
+		for (var i = 0; i < times; i++) {
+			wgt.setRunning(false);
+			wgt.setRunning(true);
+		}
+	};
+	// runs whatever zAu really holds; 0 is not one of the codes zul.utl.Timer acts on
+	window.zk6090tm.probe = function () {
+		window.zk6090tm.calls = 0;
+		zAu.onResponseError({headers: {get: function () { return null; }}}, 0);
+		return window.zk6090tm.calls;
+	};
+	window.zk6090tm.state = function () {
+		var wgt = zk.Widget.$('$tm');
+		return '' + wgt.isRepeats() + '/' + wgt.isRunning();
+	};
+	]]></script>
+</zk>

--- a/zktest/src/main/webapp/test2/B110-ZK-6090-TouchSwipe.zul
+++ b/zktest/src/main/webapp/test2/B110-ZK-6090-TouchSwipe.zul
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?script content="window.zk6090={errors:[]};window.addEventListener('error',function(evt){window.zk6090.errors.push(''+(evt.message||evt.error));});"?>
+<!--
+B110-ZK-6090-TouchSwipe.zul
+
+	Purpose:
+
+	Description:
+
+	History:
+		Fri Aug 21 11:00:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+	<label multiline="true">
+		Steps (mobile/touch emulation with the tablet UI on):
+		1. Every widget below listens to onSwipe, so the zkmax touch molds give each of
+		   them a zk.Swipe 300ms after mount.
+		2. Unbinding them must not throw "Node ... is not found" and must leave no
+		   swipe behind.
+	</label>
+	Tablet UI? <label id="tabletUI"/>
+
+	<calendar id="cal" onSwipe='self.setTooltiptext("swiped")'/>
+
+	<borderlayout id="bl" height="150px" width="400px">
+		<north id="rgn" size="60px" collapsible="true" onSwipe='self.setTooltiptext("swiped")'>
+			<label value="north"/>
+		</north>
+		<center>
+			<label value="center"/>
+		</center>
+	</borderlayout>
+
+	<tabbox id="tbx" width="400px" height="120px">
+		<tabs>
+			<tab label="one"/>
+		</tabs>
+		<tabpanels>
+			<tabpanel id="tp" onSwipe='self.setTooltiptext("swiped")'>
+				<label value="panel"/>
+			</tabpanel>
+		</tabpanels>
+	</tabbox>
+
+	<zscript><![CDATA[
+		org.zkoss.zul.ListModel cbxModel = new org.zkoss.zul.ListModelList(
+				java.util.Arrays.asList(new String[] {"alpha", "beta", "gamma"}));
+	]]></zscript>
+	<chosenbox id="cbx" width="240px" model="${cbxModel}"/>
+
+	<script><![CDATA[
+	// the tablet mold of the chosenbox watches window for resize
+	window.zk6090WindowResize = function () {
+		var e = jq._data(window, 'events') || {};
+		return '' + ((e.resize || []).length);
+	};
+	window.zk6090UnbindCbx = function () {
+		try {
+			window.zk6090.cbx.unbind();
+		} catch (e) {
+			window.zk6090.errors.push('cbx: ' + (e.message || e));
+		}
+	};
+	// unbind() drops the widget from zk.Widget.$, so hold on to it first, and report
+	// the throw instead of letting it escape into the caller
+	window.zk6090Unbind = function (name) {
+		try {
+			window.zk6090[name].unbind();
+		} catch (e) {
+			window.zk6090.errors.push(name + ': ' + (e.message || e));
+		}
+	};
+	window.zk6090HasSwipe = function (name) {
+		return '' + !!window.zk6090[name]._swipe;
+	};
+	zk.afterMount(function () {
+		zk.$('$tabletUI').setValue('' + !!zk.tabletUIEnabled);
+		window.zk6090.cal = zk.Widget.$('$cal');
+		window.zk6090.rgn = zk.Widget.$('$rgn');
+		window.zk6090.tp = zk.Widget.$('$tp');
+		window.zk6090.cbx = zk.Widget.$('$cbx');
+	});
+	]]></script>
+</zk>

--- a/zktest/src/main/webapp/test2/B110-ZK-6090-TouchUnbind.zul
+++ b/zktest/src/main/webapp/test2/B110-ZK-6090-TouchUnbind.zul
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?script content="window.zk6090={errors:[],rightClicks:0};window.addEventListener('error',function(evt){window.zk6090.errors.push(''+(evt.message||evt.error));});"?>
+<!--
+B110-ZK-6090-TouchUnbind.zul
+
+	Purpose:
+
+	Description:
+
+	History:
+		Fri Aug 21 10:20:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+	<label multiline="true">
+		Steps (touch emulation on a desktop user agent):
+		1. Touch the first box and let the page unbind it before the finger lifts:
+		   the handlers the gesture added must go away with the swipe.
+		2. Take the tap listeners off the second box, then unbind it: its touch
+		   handlers must come off even though the listeners are gone.
+		3. Press and hold the second box and let the page unbind it: no onRightClick
+		   may arrive afterwards.
+		4. No JavaScript error should appear in the browser console.
+	</label>
+
+	<div id="swiper" width="120px" height="80px" style="border:1px solid #888"
+		 onSwipe='self.setTooltiptext("swiped")'>swipe me</div>
+
+	<!-- the tap listeners are registered on the client, so they can be taken off again
+	     at run time the way an application removes a listener it no longer wants -->
+	<div id="tapper" width="120px" height="80px" style="border:1px solid #888">hold me</div>
+
+	<script><![CDATA[
+	// the touch listeners a widget carries, so a leftover one can be counted
+	window.zk6090Snap = function (node) {
+		var e = jq._data(node, 'events') || {};
+		return [(e.touchstart || []).length, (e.touchend || []).length,
+			(e.touchmove || []).length].join(',');
+	};
+	// a real touch event, so the handlers under test run the way a finger runs them
+	window.zk6090Touch = function (node, type) {
+		var t = new Touch({identifier: 1, target: node, clientX: 10, clientY: 10});
+		try {
+			node.dispatchEvent(new TouchEvent(type, {touches: [t], changedTouches: [t], bubbles: true}));
+		} catch (e) {
+			window.zk6090.errors.push('' + (e.message || e));
+		}
+	};
+	window.zk6090Drop = function () {
+		var s = window.zk6090;
+		s.tapper.unlisten({onDoubleClick: s.lsnDbl, onRightClick: s.lsnRight});
+	};
+	zk.afterMount(function () {
+		var swiper = zk.Widget.$('$swiper'), tapper = zk.Widget.$('$tapper');
+		// the widgets are unbound below, which takes them out of zk.Widget.$
+		window.zk6090.swiper = swiper;
+		window.zk6090.swiperNode = swiper.$n();
+		window.zk6090.tapper = tapper;
+		window.zk6090.tapperNode = tapper.$n();
+		// the baselines are read before the 300ms lazy gesture init, so the counts
+		// below only ever measure what that init added
+		window.zk6090.swiperBase = window.zk6090Snap(window.zk6090.swiperNode);
+		window.zk6090.tapperBase = window.zk6090Snap(window.zk6090.tapperNode);
+		window.zk6090.startEvt = ('ontouchstart' in window) ? 'touchstart' : 'mousedown';
+
+		window.zk6090.lsnDbl = function () {};
+		window.zk6090.lsnRight = function () {};
+		tapper.listen({onDoubleClick: window.zk6090.lsnDbl, onRightClick: window.zk6090.lsnRight});
+
+		// counts the onRightClick a pending hold timer would still deliver after the unbind
+		var doRightClick = tapper.doRightClick_;
+		tapper.doRightClick_ = function () {
+			window.zk6090.rightClicks++;
+			return doRightClick.apply(this, arguments);
+		};
+	});
+	]]></script>
+</zk>

--- a/zktest/src/main/webapp/test2/B110-ZK-6090.zul
+++ b/zktest/src/main/webapp/test2/B110-ZK-6090.zul
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+B110-ZK-6090.zul
+
+        Purpose:
+
+        Description:
+
+        History:
+                Wed May 06 16:42:49 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+	<label multiline="true">
+		Steps (using mobile/touch emulation):
+		1. Click the x on "test3".
+		2. The tab closes and no error bar (.z-error) appears.
+		3. "Touch Enabled?" and "Tablet UI?" should both be true.
+	</label>
+	Touch Enabled? <label id="touchEnabled"/>
+	Tablet UI? <label id="tabletUI"/>
+	<tabbox id="tb" width="500px" height="250px">
+		<tabs>
+			<tab label="test1"/>
+			<tab label="test2" closable="true"/>
+			<tab label="test3" closable="true"/>
+		</tabs>
+		<tabpanels>
+			<tabpanel><textbox value="plain"/></tabpanel>
+			<tabpanel><textbox value="plain"/></tabpanel>
+			<tabpanel>
+				<cardlayout id="card" width="400px" height="150px">
+					<textbox value="inside-cardlayout"/>
+				</cardlayout>
+			</tabpanel>
+		</tabpanels>
+	</tabbox>
+	<script><![CDATA[
+	zk.afterMount(function () {
+		zk.$('$touchEnabled').setValue('' + !!zk.touchEnabled);
+		zk.$('$tabletUI').setValue('' + !!zk.tabletUIEnabled);
+	});
+	]]></script>
+</zk>

--- a/zktest/src/main/webapp/test2/config.properties
+++ b/zktest/src/main/webapp/test2/config.properties
@@ -3307,6 +3307,28 @@ B90-ZK-4431.zul=A,E,Multislider
 ##zats##B110-ZK-6146.zul=A,M,Daterangebox,DaterangePopup,Timebox,showTime
 ##zats##B110-ZK-6060.zul=A,E,zul.xsd
 ##zats##B110-ZK-6080.zul=A,E,Grid,Rows,Groupfoot
+##zats##B110-ZK-6090.zul=A,E,Tabbox,Cardlayout
+##zats##B110-ZK-6090-BindSwipe.zul=A,E,Div,Swipe
+##zats##B110-ZK-6090-DomTouch.zul=A,E,Div,touch,onSwipe,onDoubleClick,onRightClick
+##zats##B110-ZK-6090-Bandpopup.zul=A,E,Bandbox,Bandpopup
+##zats##B110-ZK-6090-Spinner.zul=A,E,Spinner,Doublespinner,Timebox,Window,onChanging
+##zats##B110-ZK-6090-Frozen.zul=A,E,Grid,Frozen,onSize
+##zats##B110-ZK-6090-Nav.zul=A,E,Navbar,Nav,Navitem
+##zats##B110-ZK-6090-Coachmark.zul=A,E,Coachmark,za11y
+##zats##B110-ZK-6090-ContentHandler.zul=A,E,Menubar,Menu,Colorbox,onFloatUp
+##zats##B110-ZK-6090-FrozenSmooth.zul=A,E,Grid,Frozen,onSize
+##zats##B110-ZK-6090-Daterange.zul=A,E,Daterangebox,onFloatUp
+##zats##B110-ZK-6090-TouchUnbind.zul=A,E,Div,touch,onSwipe,onDoubleClick,onRightClick
+##zats##B110-ZK-6090-TouchSwipe.zul=A,E,Calendar,Borderlayout,Tabpanel,onSwipe
+##zats##B110-ZK-6090-KnobSlider.zul=A,E,Slider,za11y
+##zats##B110-ZK-6090-NavitemPopup.zul=A,E,Navbar,Navitem
+##zats##B110-ZK-6090-DocListener.zul=A,E,Anchornav,Borderlayout,Dropupload
+##zats##B110-ZK-6090-Teardown.zul=A,E,Biglistbox,GoldenLayout
+##zats##B110-ZK-6090-SwipeState.zul=A,E,Div,touch,onSwipe
+##zats##B110-ZK-6090-RebindGesture.zul=A,E,Div,touch,onDoubleClick,onSwipe
+##zats##B110-ZK-6090-Timer.zul=A,E,Timer,onError
+##zats##B110-ZK-6090-SlideRebind.zul=A,E,Borderlayout,West,onSlide
+##zats##B110-ZK-6090-TabboxMold.zul=A,E,Tabbox,Tabpanel,mold
 
 ##
 # Features - 3.0.x version

--- a/zktest/src/test/java/org/zkoss/zktest/zats/TabletWebDriverTestCase.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/TabletWebDriverTestCase.java
@@ -1,0 +1,56 @@
+/* TabletWebDriverTestCase.java
+
+	Purpose:
+
+	Description:
+
+	History:
+		Thu Aug 20 11:05:41 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.logging.Level;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.logging.LogType;
+
+import org.zkoss.test.webdriver.ExternalZkXml;
+import org.zkoss.test.webdriver.WebDriverTestCase;
+
+/**
+ * A base class running the browser with a tablet user agent and touch support,
+ * so that <code>zk.mobile</code>, <code>zk.touchEnabled</code> and
+ * <code>zk.tabletUIEnabled</code> are all on and the zkmax tablet molds apply.
+ *
+ * <p>A subclass must be annotated with
+ * {@link org.zkoss.test.webdriver.ForkJVMTestOnly}: the tablet UI is turned on
+ * by a library property, which is JVM wide.
+ *
+ * @author peakerlee
+ */
+public abstract class TabletWebDriverTestCase extends WebDriverTestCase {
+	/** An Android tablet user agent, so that <code>zk.mobile</code> is true. */
+	private static final String TABLET_USER_AGENT = "Mozilla/5.0 (Linux; Android 13; SM-X710)"
+			+ " AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+	/** zktest disables the tablet UI by default, turn it back on. */
+	@RegisterExtension
+	public static final ExternalZkXml TABLET_UI = new ExternalZkXml("/test2/enable-tablet-ui-zk.xml");
+
+	@Override
+	protected ChromeOptions getWebDriverOptions() {
+		ChromeOptions options = super.getWebDriverOptions()
+				.setExperimentalOption("mobileEmulation", Map.of(
+						"userAgent", TABLET_USER_AGENT,
+						"deviceMetrics", Map.of("width", 1024, "height", 768,
+								"pixelRatio", 2, "touch", true)));
+		// assertNoJSError() reads the browser console, which Chrome only exposes when asked for
+		options.setCapability("goog:loggingPrefs", Collections.singletonMap(LogType.BROWSER, Level.ALL));
+		return options;
+	}
+}

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090Test.java
@@ -1,0 +1,48 @@
+/* B110_ZK_6090Test.java
+
+        Purpose:
+
+        Description:
+
+        History:
+                Wed May 06 16:42:55 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import org.zkoss.test.webdriver.ForkJVMTestOnly;
+import org.zkoss.zktest.zats.TabletWebDriverTestCase;
+
+@ForkJVMTestOnly
+public class B110_ZK_6090Test extends TabletWebDriverTestCase {
+
+	@Test
+	public void test() {
+		connect();
+		waitResponse();
+
+		// without the tablet UI the zkmax touch molds never load and this test
+		// would exercise the CE fallback instead of zkmax.layout.Cardlayout
+		assertEquals("true", jq("$touchEnabled").text());
+		assertEquals("true", jq("$tabletUI").text());
+		// zk.Widget already declares bindSwipe_, so only an own property on the
+		// Cardlayout prototype proves the cardlayout-touch augment really loaded
+		assertEquals("true", getEval(
+				"Object.prototype.hasOwnProperty.call(zkmax.layout.Cardlayout.prototype, 'bindSwipe_')"),
+				"the cardlayout-touch augment must be installed");
+		assertEquals(3, jq("@tab").length());
+
+		// close test3 tab (index 2), whose panel contains <cardlayout>
+		click(widget("@tab:eq(2)").$n("cls"));
+		waitResponse();
+
+		assertEquals(2, jq("@tab").length());
+		assertNoAnyError();
+		assertNoJSError();
+	}
+}

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_BandpopupTest.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_BandpopupTest.java
@@ -1,0 +1,69 @@
+/* B110_ZK_6090_BandpopupTest.java
+
+	Purpose:
+
+	Description:
+
+	History:
+		Thu Aug 20 16:00:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Collections;
+import java.util.logging.Level;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.logging.LogType;
+
+import org.zkoss.test.webdriver.WebDriverTestCase;
+
+/**
+ * A bandpopup adds focusin/focusout listeners to its own node when it is bound, and its unbind
+ * has to take exactly those listeners off again.
+ *
+ * <p>The widget is unbound and bound again from the client, which is what a container doing
+ * render-on-demand does to its children: the node stays where it is, so the listeners left on it
+ * are counted instead of being thrown away with the node.
+ *
+ * @author peakerlee
+ */
+public class B110_ZK_6090_BandpopupTest extends WebDriverTestCase {
+
+	@Override
+	protected ChromeOptions getWebDriverOptions() {
+		ChromeOptions options = super.getWebDriverOptions();
+		// assertNoJSError() reads the browser console, which Chrome only exposes when asked for
+		options.setCapability("goog:loggingPrefs", Collections.singletonMap(LogType.BROWSER, Level.ALL));
+		return options;
+	}
+
+	@Test
+	public void test() {
+		connect();
+		// the popup content is rendered on demand, open the bandbox to get it
+		click(jq("$bb").find(".z-bandbox-button"));
+		waitResponse();
+		assertEquals("true", getEval("(window.__w = zk.Widget.$('$bp'), window.__n = window.__w.$n(), !!window.__n)"),
+				"the bandpopup should be rendered once the bandbox is open");
+		assertEquals("1,1", focusListeners(),
+				"binding the bandpopup should add one focusin and one focusout listener");
+
+		getEval("(window.__w.unbind(), 1)");
+		// ZK-6090: unbind_ passed a freshly bound function to off(), so nothing was taken off
+		assertEquals("0,0", focusListeners(), "unbinding the bandpopup should take both listeners off");
+
+		getEval("(window.__w.bind(), 1)");
+		assertEquals("1,1", focusListeners(), "binding again should not stack more listeners");
+		assertNoJSError();
+	}
+
+	private String focusListeners() {
+		return getEval("(function () {var e = jq._data(window.__n, 'events') || {};"
+				+ "return [(e.focusin || []).length, (e.focusout || []).length].join(',')})()");
+	}
+}

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_BindSwipeTest.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_BindSwipeTest.java
@@ -1,0 +1,93 @@
+/* B110_ZK_6090_BindSwipeTest.java
+
+        Purpose:
+
+        Description:
+
+        History:
+                Thu Aug 20 10:12:38 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Level;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.logging.LogType;
+
+import org.zkoss.test.webdriver.ForkJVMTestOnly;
+import org.zkoss.test.webdriver.WebDriverTestCase;
+
+@ForkJVMTestOnly
+public class B110_ZK_6090_BindSwipeTest extends WebDriverTestCase {
+
+	@Override
+	protected ChromeOptions getWebDriverOptions() {
+		// touch capability without a mobile user agent, so zk.touchEnabled is on
+		// while zk.tabletUIEnabled (and the EE tablet molds) stay off
+		Map<String, Object> deviceMetrics = new HashMap<>();
+		deviceMetrics.put("width", 1920);
+		deviceMetrics.put("height", 1080);
+		deviceMetrics.put("pixelRatio", 1.0);
+		deviceMetrics.put("touch", true);
+		deviceMetrics.put("mobile", false);
+		Map<String, Object> mobileEmulation = new HashMap<>();
+		mobileEmulation.put("deviceMetrics", deviceMetrics);
+		ChromeOptions options = super.getWebDriverOptions()
+				.setExperimentalOption("mobileEmulation", mobileEmulation);
+		// assertNoJSError() reads the browser console, which Chrome only exposes when asked for
+		options.setCapability("goog:loggingPrefs", Collections.singletonMap(LogType.BROWSER, Level.ALL));
+		return options;
+	}
+
+	@Test
+	public void test() {
+		connect();
+		waitResponse();
+
+		// touch gestures must be on, tablet molds must stay off (CE-only path)
+		assertEquals("true", jq("$touchEnabled").text(),
+				"zk.touchEnabled, navigator.maxTouchPoints=" + jq("$maxTouch").text());
+		assertEquals("false", jq("$tabletUI").text());
+
+		// wait past the 300ms lazy gesture-init timer opened by Widget.bind_
+		sleep(1500);
+
+		assertEquals("true", getEval("!!window.zk6090.boundBeforeDetach"),
+				"the div must have been bound before it was detached");
+		assertEquals("true", getEval("!!window.zk6090.unboundAfterDetach"),
+				"the div must have been unbound by the detach");
+
+		// the ordering is observed, not inferred from the sleep above: the keeper's
+		// bindSwipe_ marks when the 300ms timers fired, and the detach must precede it
+		int keeperSeq = Integer.parseInt(getEval("window.zk6090.keeperSeq"));
+		int detachSeq = Integer.parseInt(getEval("window.zk6090.detachSeq"));
+		assertTrue(keeperSeq > 0, "the 300ms lazy gesture-init timer never fired, nothing was tested");
+		assertTrue(detachSeq > 0 && detachSeq < keeperSeq,
+				"the detach must land inside the 300ms window; detachSeq=" + detachSeq
+						+ " keeperSeq=" + keeperSeq);
+
+		// the core assertion: the timer must not enter bindSwipe_ on the unbound widget
+		assertEquals("0", getEval("window.zk6090.targetSeq"),
+				"lazy gesture init ran on the detached widget, desktop="
+						+ getEval("window.zk6090.targetDesktopAtCall"));
+		assertEquals("", getEval("window.zk6090.errors.join('|')"),
+				"the lazy gesture init must not run on an unbound widget");
+
+		// and the guard must not simply disable the feature
+		assertEquals("true", getEval("!!zk.Widget.$('$keeper')._swipe"),
+				"a widget that stays bound must still get its zk.Swipe");
+		assertEquals("true", getEval("!!zk.Widget.$('$knob')._swipe"),
+				"the knob slider must still get its zk.Swipe");
+
+		assertNoJSError();
+	}
+}

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_CoachmarkTest.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_CoachmarkTest.java
@@ -1,0 +1,120 @@
+/* B110_ZK_6090_CoachmarkTest.java
+
+	Purpose:
+
+	Description:
+
+	History:
+		Thu Aug 21 10:00:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.util.Collections;
+import java.util.logging.Level;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.logging.LogType;
+
+import org.zkoss.test.webdriver.WebDriverTestCase;
+
+/**
+ * The accessibility layer of a coachmark listens for animationend on the coachmark node, and its
+ * unbind has to take exactly that listener off again.
+ *
+ * <p>The widget is unbound and bound again from the client, which is what a container doing
+ * render-on-demand does to its children: the node stays where it is, so a listener that was not
+ * taken off is counted on it instead of being thrown away with the node.
+ *
+ * <p>The listener only exists when the accessibility layer is loaded, so the test is a no-op in
+ * the NO_A11Y variant.
+ *
+ * @author peakerlee
+ */
+public class B110_ZK_6090_CoachmarkTest extends WebDriverTestCase {
+
+	@Override
+	protected ChromeOptions getWebDriverOptions() {
+		ChromeOptions options = super.getWebDriverOptions();
+		// assertNoJSError() reads the browser console, which Chrome only exposes when asked for
+		options.setCapability("goog:loggingPrefs", Collections.singletonMap(LogType.BROWSER, Level.ALL));
+		return options;
+	}
+
+	@Test
+	public void test() {
+		connect();
+		waitResponse();
+		if (!Boolean.parseBoolean(getEval("!!window.za11y")))
+			return; // the animationend listener belongs to the accessibility layer
+
+		assertEquals("true", getEval("(window.__w = zk.Widget.$('$cm'), window.__n = window.__w.$n(), !!window.__n)"),
+				"the coachmark node should be in the page");
+		assertEquals("1", animationEndListeners(),
+				"binding the coachmark should add one animationend listener");
+
+		getEval("(window.__w.unbind(), 1)");
+		// ZK-6090: unbind_ passed a freshly bound function to off(), so nothing was taken off
+		assertEquals("0", animationEndListeners(),
+				"unbinding the coachmark should take the animationend listener off");
+		// the leftover listener used to reach for the -cls node of a widget that no longer has one
+		getEval("(jq(window.__n).trigger('animationend'), 1)");
+
+		getEval("(window.__w.bind(), 1)");
+		assertEquals("1", animationEndListeners(), "binding again should not stack another listener");
+		assertNoJSError();
+	}
+
+	/**
+	 * While a coachmark highlights its target it puts a click listener on the target's node,
+	 * which belongs to another widget and outlives the coachmark. Restoring the target has to
+	 * take that very listener off again.
+	 */
+	@Test
+	public void testTargetClickListener() {
+		connect();
+		waitResponse();
+		assertEquals("true", getEval("(window.__cm = zk.Widget.$('$cm'),"
+						+ " window.__t = zk.Widget.$('$target').$n(), !!window.__t)"),
+				"the target button should be in the page");
+		String base = targetClickListeners();
+
+		// the coachmark puts a modal mask over the page, so it is toggled from the client
+		// rather than by clicking through the mask
+		toggle(true);
+		assertNotEquals(base, targetClickListeners(),
+				"showing the coachmark should put a click listener on its target");
+
+		toggle(false);
+		// ZK-6090: _highlightTarget used bind() and _restoreTarget used proxy(), so the
+		// off() matched nothing and every show/hide cycle stacked another handler
+		assertEquals(base, targetClickListeners(),
+				"hiding the coachmark must take its click listener off the target");
+
+		toggle(true);
+		toggle(false);
+		assertEquals(base, targetClickListeners(),
+				"a second show/hide cycle must not stack another handler either");
+		assertNoJSError();
+	}
+
+	private String animationEndListeners() {
+		return getEval("(function () {var e = jq._data(window.__n, 'events') || {};"
+				+ "return String((e.animationend || []).length)})()");
+	}
+
+	private void toggle(boolean visible) {
+		getEval("(window.__cm.setVisible(" + visible + "), 1)");
+		sleep(600); // the coachmark slides in and out
+	}
+
+	private String targetClickListeners() {
+		return getEval("(function () {var e = jq._data(window.__t, 'events') || {};"
+				+ "return String((e.click || []).length)})()");
+	}
+}

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_ContentHandlerTest.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_ContentHandlerTest.java
@@ -1,0 +1,112 @@
+/* B110_ZK_6090_ContentHandlerTest.java
+
+	Purpose:
+
+	Description:
+
+	History:
+		Thu Aug 21 10:00:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.Collections;
+import java.util.logging.Level;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.logging.LogType;
+
+import org.zkoss.test.webdriver.WebDriverTestCase;
+
+/**
+ * The content handler of a menu registers the menu for the onFloatUp and onHide watches and puts
+ * three listeners on the content popup node. Unbinding the menu has to give all of that back.
+ *
+ * <p>onFloatUp is not one of the visibility watches, so zWatch does not filter out an unbound
+ * listener: a menu left in the watch list keeps being called after it is gone.
+ *
+ * @author peakerlee
+ */
+public class B110_ZK_6090_ContentHandlerTest extends WebDriverTestCase {
+
+	@Override
+	protected ChromeOptions getWebDriverOptions() {
+		ChromeOptions options = super.getWebDriverOptions();
+		// assertNoJSError() reads the browser console, which Chrome only exposes when asked for
+		options.setCapability("goog:loggingPrefs", Collections.singletonMap(LogType.BROWSER, Level.ALL));
+		return options;
+	}
+
+	/** The onFloatUp/onHide watch registration must not survive the menu it was made for. */
+	@Test
+	public void testWatchList() {
+		connect();
+		waitResponse();
+		// the colour content handler lives in zkex and is fetched on demand
+		waitFor("String(!!zk.Widget.$('$m')._contentHandler)", "the zkex content handler never arrived");
+
+		assertEquals("true", getEval("zk6090Spy('$m')"), "the menu should own a content handler");
+		getEval("(zk6090FloatUp(), 1)");
+		assertEquals("1", getEval("zk6090Hits('$m')"),
+				"a bound menu with a content is called on onFloatUp");
+
+		getEval("(zk6090Unbind('$m'), 1)");
+		getEval("(zk6090FloatUp(), 1)");
+		// ZK-6090: unbind() never gave the onFloatUp/onHide watches back, so the menu was still
+		// called after it had been unbound
+		assertEquals("1", getEval("zk6090Hits('$m')"),
+				"an unbound menu should no longer be called on onFloatUp");
+
+		getEval("(zk6090Bind('$m'), 1)");
+		getEval("(zk6090FloatUp(), 1)");
+		assertEquals("2", getEval("zk6090Hits('$m')"),
+				"binding the menu again should put it back in the watch list");
+		assertNoJSError();
+	}
+
+	/**
+	 * The three listeners bind() puts on the content popup node are added whatever the menu
+	 * carries, so unbind() has to take them off the same way. A menu that gains a menupopup while
+	 * it is bound (what Menu.onChildAdded_ does) is unbound with menupopup already set.
+	 */
+	@Test
+	public void testContentPopupListeners() {
+		connect();
+		waitResponse();
+		waitFor("String(!!zk.Widget.$('$m2')._contentHandler)", "the zkex content handler never arrived");
+
+		assertEquals("true", getEval("zk6090Spy('$m2')"), "the second menu should own a content handler");
+		getEval("(zk6090FloatUp(), 1)");
+		assertEquals("1", getEval("zk6090Hits('$m2')"),
+				"a bound menu with a content is called on onFloatUp");
+
+		assertEquals("true", getEval("zk6090GainMenupopup()"),
+				"the second menu should have a content popup node to start with");
+		// ZK-6090: the whole removal block sat inside if (!wgt.menupopup), so the listeners were
+		// left on a node the handler no longer even points at
+		assertEquals("0,0,0", getEval("zk6090Pp2Listeners()"),
+				"unbinding should take the content popup listeners off even when a menupopup arrived");
+
+		getEval("(zk6090FloatUp(), 1)");
+		// re-testing menupopup in unbind() reads a state bind() never saw: onChildAdded_ sets it
+		// before the rerender, so the watch registration was never given back
+		assertEquals("1", getEval("zk6090Hits('$m2')"),
+				"an unbound menu that gained a menupopup must leave the watch list");
+		assertNoJSError();
+	}
+
+	/** Polls a JS expression that evaluates to a boolean until it turns true. */
+	private void waitFor(String jsBooleanExpr, String message) {
+		for (int i = 0; i < 50; i++) {
+			if ("true".equals(getEval(jsBooleanExpr)))
+				return;
+			sleep(100);
+		}
+		fail(message);
+	}
+}

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_DaterangeTest.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_DaterangeTest.java
@@ -1,0 +1,63 @@
+/* B110_ZK_6090_DaterangeTest.java
+
+	Purpose:
+
+	Description:
+
+	History:
+		Thu Aug 21 10:00:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import org.zkoss.test.webdriver.WebDriverTestCase;
+
+/**
+ * An open daterange popup puts itself in the onFloatUp watch list so that a click elsewhere closes
+ * it, and only close() takes it out again. A popup unbound while it is open therefore keeps being
+ * called, and reaches for a node that went away with the binding.
+ *
+ * <p>onFloatUp is not one of the visibility watches, so zWatch does not filter out the unbound
+ * listener by itself.
+ *
+ * @author peakerlee
+ */
+public class B110_ZK_6090_DaterangeTest extends WebDriverTestCase {
+
+	@Test
+	public void test() {
+		connect();
+		waitResponse();
+
+		// control: a bound popup still closes on an outside float up
+		openPopup("$drCtrl");
+		assertEquals("true", getEval("zk6090PopupOpen('$drCtrl')"),
+				"the control popup should be open");
+		assertEquals("ok", getEval("zk6090FloatUp()"), "firing onFloatUp should not throw");
+		assertEquals("false", getEval("zk6090PopupOpen('$drCtrl')"),
+				"an outside float up should close a bound popup");
+
+		// the popup is unbound while still open, which is what a container doing
+		// render-on-demand does to its children
+		openPopup("$dr");
+		assertEquals("true", getEval("zk6090UnbindPopup('$dr')"),
+				"the first box should own a popup");
+		assertEquals("false", getEval("String(!!window.zk6090Popup.desktop)"),
+				"the popup should have been unbound");
+		// ZK-6090: unbind_ left the popup in the watch list, so onFloatUp reached close() and
+		// its this.$n_() on a widget whose node was already gone
+		assertEquals("ok", getEval("zk6090FloatUp()"),
+				"an unbound popup should no longer be called on onFloatUp");
+		assertNoAnyError();
+	}
+
+	private void openPopup(String boxId) {
+		click(jq(boxId + " .z-daterangebox-button"));
+		waitResponse();
+	}
+}

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_DocListenerTest.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_DocListenerTest.java
@@ -1,0 +1,139 @@
+/* B110_ZK_6090_DocListenerTest.java
+
+	Purpose:
+
+	Description:
+
+	History:
+		Fri Aug 21 14:30:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import java.util.logging.Level;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.logging.LogType;
+
+import org.zkoss.test.webdriver.WebDriverTestCase;
+
+/**
+ * A listener a widget puts on document or window outlives every node the widget owns, so it can
+ * only go away if the widget's own teardown takes it off. Each case below unbinds one widget and
+ * checks that exactly its own listener disappeared.
+ *
+ * @author peakerlee
+ */
+public class B110_ZK_6090_DocListenerTest extends WebDriverTestCase {
+
+	@Override
+	protected ChromeOptions getWebDriverOptions() {
+		ChromeOptions options = super.getWebDriverOptions();
+		// assertNoJSError() reads the browser console, which Chrome only exposes when asked for
+		options.setCapability("goog:loggingPrefs", Collections.singletonMap(LogType.BROWSER, Level.ALL));
+		return options;
+	}
+
+	/** The anchornav puts a scroll listener on window when it finds no explicit scroll target. */
+	@Test
+	public void testAnchornavWindowScroll() {
+		connect();
+		waitResponse();
+		int before = count("window", "scroll");
+		assertTrue(before > 0, "the anchornav should have put a scroll listener on window");
+
+		getEval("(window.zk6090Unbind('an'), 1)");
+		assertEquals(before - 1, count("window", "scroll"),
+				"unbinding the anchornav must take its window scroll listener off");
+		assertEquals("", getEval("window.zk6090.errors.join('|')"), "unbinding threw");
+		assertNoJSError();
+	}
+
+	/** A collapsed region that has slid out listens on document for the click that closes it. */
+	@Test
+	public void testLayoutRegionDocumentClick() {
+		connect();
+		waitResponse();
+		int base = count("document", "click");
+
+		getEval("(window.zk6090.rgn.setSlide(true), 1)");
+		sleep(1000); // the slide is animated, the listener goes on in afterSlideDown
+		int slid = count("document", "click");
+		assertEquals(base + 1, slid, "sliding the region out should add its document click listener");
+
+		getEval("(window.zk6090Unbind('rgn'), 1)");
+		assertEquals(base, count("document", "click"),
+				"unbinding a region that is still slid out must take its document click listener off");
+		assertEquals("", getEval("window.zk6090.errors.join('|')"), "unbinding threw");
+		assertNoJSError();
+	}
+
+	/** detection="browser" makes the dropupload watch the whole document for a drag. */
+	@Test
+	public void testDropuploadDocumentDrag() {
+		connect();
+		waitResponse();
+		int before = count("document", "dragenter");
+		assertTrue(before > 0, "the dropupload should watch document for dragenter");
+
+		getEval("(window.zk6090Unbind('du'), 1)");
+		assertEquals(before - 1, count("document", "dragenter"),
+				"unbinding the dropupload must take its document dragenter listener off");
+		assertEquals(0, count("document", "dragleave"),
+				"and its dragleave listener as well");
+		assertEquals("", getEval("window.zk6090.errors.join('|')"), "unbinding threw");
+		assertNoJSError();
+	}
+
+	/**
+	 * When a dedicated scroll target appears, its bind_ moves the anchornav off the window
+	 * fallback and onto the target's own cave node. Unbinding the target has to undo both
+	 * halves of that hand-off.
+	 */
+	@Test
+	public void testScrollTargetHandsAnchornavBack() {
+		connect();
+		waitResponse();
+		assertEquals(1, countCave("scroll"),
+				"the scroll target should carry the anchornav's scroll listener");
+		int windowBefore = count("window", "scroll");
+
+		getEval("(window.zk6090Unbind('scroller'), 1)");
+		assertEquals(0, countCave("scroll"),
+				"unbinding the scroll target must take the anchornav's listener off its cave");
+		assertEquals(windowBefore + 1, count("window", "scroll"),
+				"and must hand the anchornav back to the window fallback its bind_ removed");
+		assertEquals("", getEval("window.zk6090.errors.join('|')"), "unbinding threw");
+		assertNoJSError();
+	}
+
+	/** The other direction: the target outlives the anchornav, so the anchornav must clean up. */
+	@Test
+	public void testAnchornavReleasesItsScrollTarget() {
+		connect();
+		waitResponse();
+		assertEquals(1, countCave("scroll"),
+				"the scroll target should carry the anchornav's scroll listener");
+
+		getEval("(window.zk6090Unbind('an2'), 1)");
+		assertEquals(0, countCave("scroll"),
+				"unbinding the anchornav must take its listener off the scroll target it does not own");
+		assertEquals("", getEval("window.zk6090.errors.join('|')"), "unbinding threw");
+		assertNoJSError();
+	}
+
+	private int count(String target, String type) {
+		return Integer.parseInt(getEval("'' + window.zk6090Count('" + target + "', '" + type + "')"));
+	}
+
+	private int countCave(String type) {
+		return Integer.parseInt(
+				getEval("'' + window.zk6090CountNode(window.zk6090.scrollerCave, '" + type + "')"));
+	}
+}

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_DomTouchTest.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_DomTouchTest.java
@@ -1,0 +1,98 @@
+/* B110_ZK_6090_DomTouchTest.java
+
+	Purpose:
+
+	Description:
+
+	History:
+		Thu Aug 20 16:00:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.logging.Level;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.logging.LogType;
+
+import org.zkoss.test.webdriver.WebDriverTestCase;
+
+/**
+ * The touch listeners a widget gets on a touch device are added to its own node, so unbinding it
+ * has to take them off that very node instead of off the one it no longer has.
+ *
+ * <p>The widget is unbound and bound again from the client, which is what a container doing
+ * render-on-demand does to its children: the node stays where it is, so the listeners left on it
+ * are counted instead of being thrown away with the node.
+ *
+ * @author peakerlee
+ */
+public class B110_ZK_6090_DomTouchTest extends WebDriverTestCase {
+
+	/** A plain desktop user agent: only the touch support is emulated, not a mobile device. */
+	private static final String DESKTOP_USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)"
+			+ " AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+	@Override
+	protected ChromeOptions getWebDriverOptions() {
+		ChromeOptions options = super.getWebDriverOptions();
+		// assertNoJSError() reads the browser console, which Chrome only exposes when asked for
+		options.setCapability("goog:loggingPrefs", Collections.singletonMap(LogType.BROWSER, Level.ALL));
+		// --touch-events=enabled only defines ontouchstart, it leaves maxTouchPoints at 0
+		return options.setExperimentalOption("mobileEmulation", Map.of(
+				"userAgent", DESKTOP_USER_AGENT,
+				"deviceMetrics", Map.of("width", 1280, "height", 900, "pixelRatio", 1, "touch", true)));
+	}
+
+	@Test
+	public void test() {
+		connect();
+		assertEquals("true", getEval("String(navigator.maxTouchPoints > 0)"), "touch should be emulated");
+		assertEquals("true", getEval("String(!!zk.touchEnabled)"), "zk.touchEnabled should be on");
+		assertEquals("false", getEval("String(!!zk.tabletUIEnabled)"),
+				"the tablet UI should stay off, this is a desktop user agent");
+
+		// the touch listeners are added 300ms after the widget is bound
+		sleep(1000);
+		assertEquals("true", getEval("(window.__w = zk.Widget.$('$d'), window.__n = window.__w.$n(), !!window.__n)"));
+		assertEquals("true", getEval("String(!!window.__w._swipe)"), "onSwipe should be bound");
+		String bound = touchListeners();
+		assertNotEquals("0,0,0", bound, "the touch listeners should be bound by now");
+
+		getEval("(window.__w.unbind(), 1)");
+		// ZK-6090: the unbind hooks looked the node up again after the widget had lost it, so
+		// jq(undefined).off(...) removed nothing and the dead handlers stayed on the node
+		assertEquals("0,0,0", touchListeners(),
+				"unbinding should take the touch listeners away, they were bound as " + bound);
+
+		// a dead handler still on the node throws as soon as it runs again, because unbindTapHold_
+		// already cleared the state it needs
+		getEval("(function () {var t = new Touch({identifier: 1, target: window.__n, clientX: 1, clientY: 1});"
+				+ "window.__n.dispatchEvent(new TouchEvent('touchstart',"
+				+ " {touches: [t], changedTouches: [t], bubbles: true})); return 1})()");
+		assertEquals("0", getEval("window.zk6090Errors.length"),
+				"a leftover touch listener threw: " + getEval("window.zk6090Errors.join(' | ')"));
+
+		// binding again must not stack a second set of listeners on the same node
+		getEval("(window.__w.bind(), 1)");
+		sleep(1000);
+		assertEquals(bound, touchListeners(), "binding again should not stack more listeners");
+
+		click(jq("$detach"));
+		waitResponse();
+		assertNoAnyError();
+	}
+
+	private String touchListeners() {
+		return getEval("(function () {var e = jq._data(window.__n, 'events') || {};"
+				+ "return [(e.touchstart || []).length, (e.touchend || []).length,"
+				+ " (e.touchmove || []).length].join(',')})()");
+	}
+}

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_FrozenSmoothTest.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_FrozenSmoothTest.java
@@ -1,0 +1,86 @@
+/* B110_ZK_6090_FrozenSmoothTest.java
+
+	Purpose:
+
+	Description:
+
+	History:
+		Thu Aug 21 10:00:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Collections;
+import java.util.logging.Level;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.logging.LogType;
+
+import org.zkoss.test.webdriver.WebDriverTestCase;
+
+/**
+ * The smooth frozen column brings its own onSize, which also finishes its work in a timer, so a
+ * frozen that is unbound before the timer fires has to take the timer away with it. The plain
+ * onSize is covered by {@link B110_ZK_6090_FrozenTest}; this is the smooth counterpart, which is
+ * what a grid uses by default.
+ *
+ * @author peakerlee
+ */
+public class B110_ZK_6090_FrozenSmoothTest extends WebDriverTestCase {
+	/** the sizing timer is 0ms away; half a second is a wide margin */
+	private static final long SETTLE_MS = 500;
+
+	@Override
+	protected ChromeOptions getWebDriverOptions() {
+		ChromeOptions options = super.getWebDriverOptions();
+		// assertNoJSError() reads the browser console, which Chrome only exposes when asked for
+		options.setCapability("goog:loggingPrefs", Collections.singletonMap(LogType.BROWSER, Level.ALL));
+		return options;
+	}
+
+	@Test
+	public void test() {
+		connect();
+		waitResponse();
+		sleep(SETTLE_MS);
+		assertNoError("mounting the page");
+		// onSize only reaches the timer when the grid draws a native scrollbar
+		assertEquals("true", getEval("String(!!zk.Widget.$('$g')._nativebar)"),
+				"the grid should draw a native scrollbar");
+		assertEquals("2", getEval("String(zk.Widget.$('$fz')._columns)"),
+				"onSize() gives up unless the frozen has columns");
+		assertEquals("true", getEval("String(zk.Widget.$('$fz')._smoothFrozenEnabled())"),
+				"this page is about the smooth onSize, which is the default");
+
+		// the widget is unreachable by id once it is unbound, so hold on to it
+		eval("window.zk6090Fz = zk.Widget.$('$fz')");
+		// the page sizes the frozen and drops it in the same task, leaving the timer behind
+		click(jq("$drop"));
+		waitResponse();
+		assertEquals("false", getEval("String(!!window.zk6090Fz.desktop)"),
+				"the frozen should have been dropped right after onSize");
+		sleep(SETTLE_MS);
+		// ZK-6090: the smooth onSize kept no handle, so the leftover timer ran _onSizeLater on a
+		// frozen whose nodes were gone
+		assertNoError("dropping the frozen");
+
+		// the control still sizes its frozen the ordinary way
+		click(jq("$dropCtrl"));
+		waitResponse();
+		sleep(SETTLE_MS);
+		assertEquals("true", getEval("String(!!zk.Widget.$('$fzCtrl').desktop)"),
+				"the control frozen should still be bound");
+		assertNoError("resizing the control");
+	}
+
+	/** The throw happens in a timer callback, so the page collects it through window.onerror. */
+	private void assertNoError(String action) {
+		assertEquals("0", getEval("window.zk6090Errors.length"),
+				action + " threw: " + getEval("window.zk6090Errors.join(' | ')"));
+		assertNoAnyError();
+	}
+}

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_FrozenTest.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_FrozenTest.java
@@ -1,0 +1,83 @@
+/* B110_ZK_6090_FrozenTest.java
+
+	Purpose:
+
+	Description:
+
+	History:
+		Thu Aug 20 17:30:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Collections;
+import java.util.logging.Level;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.logging.LogType;
+
+import org.zkoss.test.webdriver.WebDriverTestCase;
+
+/**
+ * Frozen.onSize() finishes its work in a timer, so a frozen that is unbound before the timer fires
+ * has to take the timer away with it.
+ *
+ * @author peakerlee
+ */
+public class B110_ZK_6090_FrozenTest extends WebDriverTestCase {
+	/** the sizing timer is 0ms away; half a second is a wide margin */
+	private static final long SETTLE_MS = 500;
+
+	@Override
+	protected ChromeOptions getWebDriverOptions() {
+		ChromeOptions options = super.getWebDriverOptions();
+		// assertNoJSError() reads the browser console, which Chrome only exposes when asked for
+		options.setCapability("goog:loggingPrefs", Collections.singletonMap(LogType.BROWSER, Level.ALL));
+		return options;
+	}
+
+	@Test
+	public void test() {
+		connect();
+		waitResponse();
+		sleep(SETTLE_MS);
+		assertNoError("mounting the page");
+		// onSize only reaches the timer when the grid draws a native scrollbar
+		assertEquals("true", getEval("String(!!zk.Widget.$('$g')._nativebar)"),
+				"the grid should draw a native scrollbar");
+		assertEquals("2", getEval("String(zk.Widget.$('$fz')._columns)"),
+				"onSize() gives up unless the frozen has columns");
+		assertEquals("false", getEval("String(!!zk.Widget.$('$fz')._smooth)"),
+				"the smooth mold replaces onSize, so this page turns it off");
+
+		// the widget is unreachable by id once it is unbound, so hold on to it
+		eval("window.zk6090Fz = zk.Widget.$('$fz')");
+		// the page sizes the frozen and drops it in the same task, leaving the timer behind
+		click(jq("$drop"));
+		waitResponse();
+		assertEquals("false", getEval("String(!!window.zk6090Fz.desktop)"),
+				"the frozen should have been dropped right after onSize");
+		sleep(SETTLE_MS);
+		// ZK-6090 threw "Node with cave is not found!" out of the leftover sizing timer
+		assertNoError("dropping the frozen");
+
+		// the control still sizes its frozen the ordinary way
+		click(jq("$dropCtrl"));
+		waitResponse();
+		sleep(SETTLE_MS);
+		assertEquals("true", getEval("String(!!zk.Widget.$('$fzCtrl').desktop)"),
+				"the control frozen should still be bound");
+		assertNoError("resizing the control");
+	}
+
+	/** The throw happens in a timer callback, so the page collects it through window.onerror. */
+	private void assertNoError(String action) {
+		assertEquals("0", getEval("window.zk6090Errors.length"),
+				action + " threw: " + getEval("window.zk6090Errors.join(' | ')"));
+		assertNoAnyError();
+	}
+}

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_KnobSliderTest.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_KnobSliderTest.java
@@ -1,0 +1,107 @@
+/* B110_ZK_6090_KnobSliderTest.java
+
+	Purpose:
+
+	Description:
+
+	History:
+		Fri Aug 21 11:40:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.util.Collections;
+import java.util.logging.Level;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.logging.LogType;
+
+import org.zkoss.test.webdriver.WebDriverTestCase;
+
+/**
+ * The knob mold of the slider adds a Draggable, two wheel handlers and, with za11y on,
+ * two focus handlers. Unbinding has to take all of them off again, and so does switching
+ * to another mold, which changes the mold before it redraws.
+ *
+ * @author peakerlee
+ */
+public class B110_ZK_6090_KnobSliderTest extends WebDriverTestCase {
+
+	@Override
+	protected ChromeOptions getWebDriverOptions() {
+		ChromeOptions options = super.getWebDriverOptions();
+		// assertNoJSError() reads the browser console, which Chrome only exposes when asked for
+		options.setCapability("goog:loggingPrefs", Collections.singletonMap(LogType.BROWSER, Level.ALL));
+		return options;
+	}
+
+	/**
+	 * The handlers were registered with freshly bound functions, so taking them off with
+	 * another freshly bound function matched nothing and left them on the node.
+	 */
+	@Test
+	public void testUnbindReleasesHandlers() {
+		connect();
+		waitResponse();
+		assertEquals("true", getEval("'' + !!window.zk6090.knob._knobDrag"),
+				"the knob mold should have bound its Draggable");
+		String bound = getEval("window.zk6090Handlers()");
+		assertNotEquals("0,0,0,0", bound, "the knob mold should have bound its handlers");
+
+		// the node stays in the page, the way a render-on-demand container recycles it
+		getEval("(window.zk6090.knob.unbind(), 1)");
+		assertEquals("0,0,0,0", getEval("window.zk6090Handlers()"),
+				"unbinding must take every knob handler off, they were bound as " + bound);
+		assertEquals("false", getEval("'' + !!window.zk6090.knob._knobDrag"),
+				"unbinding must release the knob Draggable");
+		assertEquals("", getEval("window.zk6090.errors.join('|')"), "unbinding threw");
+		assertNoJSError();
+	}
+
+	/**
+	 * setMold() assigns the new mold and only then redraws, so a teardown that asks
+	 * whether the mold is still "knob" never runs.
+	 */
+	@Test
+	public void testMoldSwitchReleasesHandlers() {
+		connect();
+		waitResponse();
+		assertEquals("true", getEval("'' + !!zul.inp.Slider.molds['default']"),
+				"the plain mold must be on the client for the switch to redraw");
+		assertEquals("true", getEval("'' + !!window.zk6090.knob._knobDrag"),
+				"the knob mold should have bound its Draggable");
+
+		getEval("(window.zk6090.knob.setMold('default'), 1)");
+		sleep(500);
+		assertEquals("default", getEval("window.zk6090.knob.getMold()"), "the mold switch did not take");
+		assertEquals("false", getEval("'' + !!window.zk6090.knob._knobDrag"),
+				"switching away from the knob mold must release the knob Draggable");
+		assertEquals("", getEval("window.zk6090.errors.join('|')"), "the mold switch threw");
+		assertNoJSError();
+	}
+
+	/**
+	 * The same trap on the CE half: the plain mold's teardown was skipped whenever the
+	 * mold read "knob" at unbind time, which is exactly what a switch <em>to</em> knob does.
+	 */
+	@Test
+	public void testMoldSwitchToKnobReleasesHandlers() {
+		connect();
+		waitResponse();
+		assertEquals("true", getEval("'' + !!window.zk6090.plain._drag"),
+				"the plain mold should have bound its Draggable");
+
+		getEval("(window.zk6090.plain.setMold('knob'), 1)");
+		sleep(500);
+		assertEquals("knob", getEval("window.zk6090.plain.getMold()"), "the mold switch did not take");
+		assertEquals("false", getEval("'' + !!window.zk6090.plain._drag"),
+				"switching to the knob mold must release the plain mold's Draggable");
+		assertEquals("", getEval("window.zk6090.errors.join('|')"), "the mold switch threw");
+		assertNoJSError();
+	}
+}

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_NavTest.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_NavTest.java
@@ -1,0 +1,61 @@
+/* B110_ZK_6090_NavTest.java
+
+	Purpose:
+
+	Description:
+
+	History:
+		Thu Aug 21 10:00:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import org.zkoss.test.webdriver.WebDriverTestCase;
+
+/**
+ * A collapsed nav pops out by moving its -text and -cave nodes to document.body, and puts them
+ * back from a timer 100ms after the mouse leaves. A nav that is unbound inside that window has to
+ * take the timer with it and put the nodes back itself, otherwise they are stranded in the page.
+ *
+ * @author peakerlee
+ */
+public class B110_ZK_6090_NavTest extends WebDriverTestCase {
+	/** the delayed close is 100ms away; a third of a second is a wide margin */
+	private static final long SETTLE_MS = 300;
+
+	@Test
+	public void test() {
+		connect();
+		waitResponse();
+
+		assertEquals("true", getEval("zk6090NavOpen()"),
+				"hovering a topmost nav of a collapsed navbar should pop it out");
+		assertEquals("true", getEval("zk6090NavAtBody()"),
+				"the popped out -text should have been moved to document.body");
+
+		// leaves the nav and drops it in the same task, so unbind_ runs while the delayed
+		// close is still pending
+		getEval("(zk6090NavLeaveAndDrop(), 1)");
+		sleep(SETTLE_MS);
+		// ZK-6090: _doMouseLeave had already cleared _shallPopup, so unbind_ skipped its
+		// teardown and left both nodes behind in document.body
+		assertEquals("", getEval("zk6090NavStrays()"),
+				"dropping the nav should take the popped out nodes with it");
+
+		// the control still pops out and closes the ordinary way
+		assertEquals("true", getEval("zk6090NavCtrlOpen()"),
+				"the control nav should pop out");
+		assertEquals("true,true", getEval("zk6090NavCtrlPopup()"),
+				"the control popup should sit in document.body while it is open");
+		getEval("(zk6090NavCtrlLeave(), 1)");
+		sleep(SETTLE_MS);
+		assertEquals("false,false", getEval("zk6090NavCtrlPopup()"),
+				"the control popup should close by itself once the mouse has left");
+		assertNoAnyError();
+	}
+}

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_NavitemPopupTest.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_NavitemPopupTest.java
@@ -1,0 +1,71 @@
+/* B110_ZK_6090_NavitemPopupTest.java
+
+	Purpose:
+
+	Description:
+
+	History:
+		Fri Aug 21 14:10:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Collections;
+import java.util.logging.Level;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.logging.LogType;
+
+import org.zkoss.test.webdriver.WebDriverTestCase;
+
+/**
+ * A navitem of a collapsed navbar pops its label out into document.body on hover and schedules
+ * the close 100ms after the pointer leaves. Unbinding inside that window has to cancel the timer
+ * and bring the label back, the same way the sibling Nav does.
+ *
+ * @author peakerlee
+ */
+public class B110_ZK_6090_NavitemPopupTest extends WebDriverTestCase {
+
+	@Override
+	protected ChromeOptions getWebDriverOptions() {
+		ChromeOptions options = super.getWebDriverOptions();
+		// assertNoJSError() reads the browser console, which Chrome only exposes when asked for
+		options.setCapability("goog:loggingPrefs", Collections.singletonMap(LogType.BROWSER, Level.ALL));
+		return options;
+	}
+
+	@Test
+	public void test() {
+		connect();
+		waitResponse();
+		assertEquals("true", getEval("'' + !!window.zk6090.textNode"), "the navitem label should exist");
+
+		// hover: the label is vparented into document.body
+		getEval("(jq(window.zk6090.ni.$n()).trigger('mouseenter'), 1)");
+		assertEquals("true", getEval("'' + !!window.zk6090.ni._isPopup"),
+				"hovering a topmost item of a collapsed navbar should pop its label out");
+		assertEquals("true", getEval("window.zk6090Orphaned()"),
+				"the popped-out label should sit in document.body");
+
+		// leave, then unbind inside the 100ms the close is delayed by
+		getEval("(jq(window.zk6090.ni.$n()).trigger('mouseleave'), 1)");
+		getEval("(window.zk6090Unbind(), 1)");
+
+		// the unbind must close the popup itself instead of leaving it to the timer
+		assertEquals("false", getEval("window.zk6090Orphaned()"),
+				"unbinding must bring the popped-out label back out of document.body");
+		assertEquals("false", getEval("'' + !!window.zk6090.ni._isPopup"),
+				"unbinding must clear the popup flag");
+
+		// and the timer must not fire on the unbound widget afterwards
+		sleep(600); // the delayed close is 100ms
+		assertEquals("", getEval("window.zk6090.errors.join('|')"),
+				"the delayed close ran on an unbound navitem");
+		assertNoJSError();
+	}
+}

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_RebindGestureTest.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_RebindGestureTest.java
@@ -1,0 +1,85 @@
+/* B110_ZK_6090_RebindGestureTest.java
+
+	Purpose:
+
+	Description:
+
+	History:
+		Mon Sep 01 14:00:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Level;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.logging.LogType;
+
+import org.zkoss.test.webdriver.ForkJVMTestOnly;
+import org.zkoss.test.webdriver.WebDriverTestCase;
+
+/**
+ * Widget.bind_ defers the swipe/double-tap/tap-hold binding by 300ms, and none of the three bind
+ * methods is idempotent. A timer left over from an earlier binding of the same widget therefore
+ * registers a second set of gesture handlers, and two double-tap handlers make a single tap report
+ * itself as a double click.
+ *
+ * @author peakerlee
+ */
+@ForkJVMTestOnly
+public class B110_ZK_6090_RebindGestureTest extends WebDriverTestCase {
+
+	@Override
+	protected ChromeOptions getWebDriverOptions() {
+		// touch capability without a mobile user agent, so zk.touchEnabled is on
+		// while zk.tabletUIEnabled (and the EE tablet molds) stay off
+		Map<String, Object> deviceMetrics = new HashMap<>();
+		deviceMetrics.put("width", 1920);
+		deviceMetrics.put("height", 1080);
+		deviceMetrics.put("pixelRatio", 1.0);
+		deviceMetrics.put("touch", true);
+		deviceMetrics.put("mobile", false);
+		Map<String, Object> mobileEmulation = new HashMap<>();
+		mobileEmulation.put("deviceMetrics", deviceMetrics);
+		ChromeOptions options = super.getWebDriverOptions()
+				.setExperimentalOption("mobileEmulation", mobileEmulation);
+		// assertNoJSError() reads the browser console, which Chrome only exposes when asked for
+		options.setCapability("goog:loggingPrefs", Collections.singletonMap(LogType.BROWSER, Level.ALL));
+		return options;
+	}
+
+	@Test
+	public void test() {
+		connect();
+		waitResponse();
+
+		// the CE gesture path only exists when touch is on
+		assertEquals("true", jq("$touchEnabled").text(), "zk.touchEnabled");
+
+		// the page rerenders the div 50ms after mount, inside the 300ms window
+		assertEquals("true", getEval("String(!!window.zk6090RG.rebound)"),
+				"the div should have been rerendered while the first timer was pending");
+
+		// wait past both 300ms lazy gesture-init timers
+		sleep(1500);
+
+		// one binding pass puts two touchstart handlers on the node (bindDoubleTap_ and the
+		// zk.Swipe constructor) and one touchend (bindDoubleTap_); bindTapHold_ registers nothing
+		// without onRightClick or a context menu.
+		// ZK-6090: unbind_ did not cancel the pending timer, so it ran against the new binding and
+		// doubled both counts, which makes a single tap report itself as a double click
+		assertEquals("2", getEval("zk6090RG.count('touchstart')"),
+				"one binding pass registers exactly two touchstart handlers");
+		assertEquals("1", getEval("zk6090RG.count('touchend')"),
+				"one binding pass registers exactly one touchend handler");
+		assertEquals("", jq("$dblLog").text(), "no gesture was performed, so nothing should be logged");
+		assertNoJSError();
+	}
+}

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_SlideRebindTest.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_SlideRebindTest.java
@@ -1,0 +1,81 @@
+/* B110_ZK_6090_SlideRebindTest.java
+
+	Purpose:
+
+	Description:
+
+	History:
+		Thu Sep 03 16:00:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Collections;
+import java.util.logging.Level;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.logging.LogType;
+
+import org.zkoss.test.webdriver.WebDriverTestCase;
+
+/**
+ * Sliding a collapsed region down is client state, so a rerender draws the region collapsed again
+ * while the widget still believes it is slid down. Unbinding has to drop that state, both flags of
+ * it: setSlide() short-circuits on the previous value, so a stale one leaves the region unable to
+ * slide at all, or sliding the wrong way.
+ *
+ * @author peakerlee
+ */
+public class B110_ZK_6090_SlideRebindTest extends WebDriverTestCase {
+
+	private static final int ANIMA_MS = 800;
+
+	@Override
+	protected ChromeOptions getWebDriverOptions() {
+		ChromeOptions options = super.getWebDriverOptions();
+		// assertNoJSError() reads the browser console, which Chrome only exposes when asked for
+		options.setCapability("goog:loggingPrefs", Collections.singletonMap(LogType.BROWSER, Level.ALL));
+		return options;
+	}
+
+	@Test
+	public void test() {
+		connect();
+		waitResponse();
+		assertEquals("false,false", getEval("zk6090SlideFlags()"),
+				"a collapsed region should start neither sliding nor slid");
+
+		// the control: the same click on a fresh binding slides the region down, otherwise the
+		// run below would prove nothing
+		click(jq("$w").find(".z-west-collapsed"));
+		sleep(ANIMA_MS);
+		assertEquals("true,true", getEval("zk6090SlideFlags()"),
+				"clicking the collapsed title should slide the region down");
+		assertEquals("true", getEval("String(zk6090SlideShown())"),
+				"the region should be shown while it is slid down");
+
+		click(jq("$rerender"));
+		sleep(ANIMA_MS);
+		assertEquals("false", getEval("String(zk6090SlideShown())"),
+				"the rerendered region should be drawn collapsed again");
+		// ZK-6090 left both flags set here, so the next setSlide() short-circuited on the stale
+		// value and the region either slid up on a collapsed DOM or did nothing at all
+		assertEquals("false,false", getEval("zk6090SlideFlags()"),
+				"rerendering should leave no slide state behind");
+
+		click(jq("$w").find(".z-west-collapsed"));
+		sleep(ANIMA_MS);
+		assertEquals("true,true", getEval("zk6090SlideFlags()"),
+				"the first click after a rerender should slide the region down again");
+		assertEquals("true", getEval("String(zk6090SlideShown())"),
+				"one click after a rerender should be enough to show the region");
+
+		assertEquals("0", getEval("window.zk6090Errors.length"),
+				"sliding after a rerender threw: " + getEval("window.zk6090Errors.join(' | ')"));
+		assertNoJSError();
+	}
+}

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_SpinnerTest.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_SpinnerTest.java
@@ -1,0 +1,84 @@
+/* B110_ZK_6090_SpinnerTest.java
+
+	Purpose:
+
+	Description:
+
+	History:
+		Thu Aug 20 16:00:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.Collections;
+import java.util.logging.Level;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.logging.LogType;
+
+import org.zkoss.test.webdriver.WebDriverTestCase;
+
+/**
+ * A spinner listens to the mouse button going up on the whole document while its arrow is held
+ * down, so unbinding it has to take that listener away. Doublespinner and Timebox reuse the same
+ * arrows and leak the same way.
+ *
+ * @author peakerlee
+ */
+public class B110_ZK_6090_SpinnerTest extends WebDriverTestCase {
+
+	@Override
+	protected ChromeOptions getWebDriverOptions() {
+		ChromeOptions options = super.getWebDriverOptions();
+		// assertNoJSError() reads the browser console, which Chrome only exposes when asked for
+		options.setCapability("goog:loggingPrefs", Collections.singletonMap(LogType.BROWSER, Level.ALL));
+		return options;
+	}
+
+	@Test
+	public void test() {
+		connect();
+		holdTheArrowUntilItIsRemoved("spinner", "sp", "spCtrl", ".z-spinner-up");
+		holdTheArrowUntilItIsRemoved("doublespinner", "dsp", "dspCtrl", ".z-doublespinner-up");
+		holdTheArrowUntilItIsRemoved("timebox", "tb", "tbCtrl", ".z-timebox-up");
+	}
+
+	private void holdTheArrowUntilItIsRemoved(String name, String id, String controlId, String upArrow) {
+		int before = bodyMouseupListeners();
+
+		// the control widget shows the listener really is added on the way down and taken away on
+		// the way up, otherwise the run below would prove nothing
+		getActions().clickAndHold(toElement(jq("$" + controlId).find(upArrow))).perform();
+		assertEquals(before + 1, bodyMouseupListeners(),
+				"holding the " + name + " arrow should register the document listener");
+		getActions().release().perform();
+		assertEquals(before, bodyMouseupListeners(),
+				"releasing the " + name + " arrow should take the document listener away");
+
+		getActions().clickAndHold(toElement(jq("$" + id).find(upArrow))).perform();
+		// onChanging closes the window while the mouse button is still down
+		for (int i = 0; i < 50 && jq("$" + id).exists(); i++)
+			sleep(100);
+		assertFalse(jq("$" + id).exists(), "the " + name + " window should be closed while the arrow is held");
+		int leaked = bodyMouseupListeners();
+
+		getActions().release().perform();
+		sleep(200);
+
+		// ZK-6090 threw "Node with btn is not found!" from the leftover document listener
+		assertEquals("0", getEval("window.zk6090Errors.length"),
+				"releasing the " + name + " arrow threw: " + getEval("window.zk6090Errors.join(' | ')"));
+		assertNoAnyError();
+		assertEquals(before, leaked, "unbinding the " + name + " should take the document listener away");
+	}
+
+	private int bodyMouseupListeners() {
+		return Integer.parseInt(getEval(
+				"String(((jq._data(document.body, 'events') || {}).mouseup || []).length)"));
+	}
+}

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_SwipeStateTest.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_SwipeStateTest.java
@@ -1,0 +1,112 @@
+/* B110_ZK_6090_SwipeStateTest.java
+
+	Purpose:
+
+	Description:
+
+	History:
+		Fri Aug 28 10:20:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Level;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.logging.LogType;
+
+import org.zkoss.test.webdriver.ForkJVMTestOnly;
+import org.zkoss.test.webdriver.WebDriverTestCase;
+
+/**
+ * zk.Swipe keeps the gesture in progress in state shared by every instance, and only
+ * the end of a gesture drops it again. Unbinding a widget takes the end handler off,
+ * so the state of that gesture must not be able to reach the next one.
+ *
+ * @author peakerlee
+ */
+@ForkJVMTestOnly
+public class B110_ZK_6090_SwipeStateTest extends WebDriverTestCase {
+
+	@Override
+	protected ChromeOptions getWebDriverOptions() {
+		// touch capability without a mobile user agent, so zk.touchEnabled is on
+		// while zk.tabletUIEnabled (and the EE tablet molds) stay off
+		Map<String, Object> deviceMetrics = new HashMap<>();
+		deviceMetrics.put("width", 1920);
+		deviceMetrics.put("height", 1080);
+		deviceMetrics.put("pixelRatio", 1.0);
+		deviceMetrics.put("touch", true);
+		deviceMetrics.put("mobile", false);
+		Map<String, Object> mobileEmulation = new HashMap<>();
+		mobileEmulation.put("deviceMetrics", deviceMetrics);
+		ChromeOptions options = super.getWebDriverOptions()
+				.setExperimentalOption("mobileEmulation", mobileEmulation);
+		// assertNoJSError() reads the browser console, which Chrome only exposes when asked for
+		options.setCapability("goog:loggingPrefs", Collections.singletonMap(LogType.BROWSER, Level.ALL));
+		return options;
+	}
+
+	@Test
+	public void test() {
+		connect();
+		waitResponse();
+
+		assertEquals("true", jq("$touchEnabled").text(), "zk.touchEnabled must be on");
+		assertEquals("true", getEval("window.zk6090s.canSynth"),
+				"the browser must provide Touch/TouchEvent, otherwise this is not a touch gesture");
+
+		sleep(1500); // the zk.Swipe is made 300ms after the widget is bound
+		assertEquals("true", getEval("window.zk6090s.hasSwipe('aborted')"),
+				"the first div never got its zk.Swipe, nothing below is tested");
+		assertEquals("true", getEval("window.zk6090s.hasSwipe('tapped')"),
+				"the second div never got its zk.Swipe, nothing below is tested");
+
+		// control: the simulated gesture really drives zk.Swipe from start to server
+		getEval("(window.zk6090s.swipe('aborted'), 1)");
+		sleep(500);
+		waitResponse();
+		assertEquals("1", getEval("window.zk6090s.abortedSwipes"),
+				"the simulated swipe never reached the widget, nothing below is tested");
+		assertEquals("A", jq("$abortedLog").text(), "the simulated swipe never reached the server");
+
+		// a gesture that is unbound before it ends: its start/stop is never consumed
+		int idle = endHandlers();
+		getEval("(window.zk6090s.gestureWithoutEnd('aborted'), 1)");
+		int inGesture = endHandlers();
+		assertTrue(inGesture > idle, "the gesture in progress must have added a touchend handler; "
+				+ idle + " -> " + inGesture);
+		getEval("(window.zk6090s.unbind('aborted'), 1)");
+		assertEquals("false", getEval("window.zk6090s.hasSwipe('aborted')"),
+				"unbinding must destroy the zk.Swipe");
+		assertTrue(endHandlers() < inGesture,
+				"destroy() must take the touchend handler off, that is what strands the gesture");
+
+		// a plain tap has no displacement at all, so it can only look like a swipe if it
+		// reads the coordinates the unbound gesture left behind
+		getEval("(window.zk6090s.tap('tapped'), 1)");
+		sleep(500);
+		waitResponse();
+		assertEquals("0", getEval("window.zk6090s.tappedSwipes"),
+				"a plain tap was reported as a swipe, on the state of the unbound gesture");
+		assertEquals("", jq("$tappedLog").text(), "a fake onSwipe reached the server");
+		assertEquals("1", getEval("window.zk6090s.abortedSwipes"),
+				"the unbound widget must not get a swipe either");
+
+		assertEquals("", getEval("window.zk6090s.errors.join('|')"), "unbinding threw");
+		assertNoJSError();
+	}
+
+	/** How many touchend handlers the first div's node carries right now. */
+	private int endHandlers() {
+		return Integer.parseInt(getEval("window.zk6090s.endHandlers('aborted')"));
+	}
+}

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_TabboxMoldTest.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_TabboxMoldTest.java
@@ -1,0 +1,97 @@
+/* B110_ZK_6090_TabboxMoldTest.java
+
+	Purpose:
+
+	Description:
+
+	History:
+		Tue Sep 09 10:20:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import org.zkoss.test.webdriver.ForkJVMTestOnly;
+import org.zkoss.zktest.zats.TabletWebDriverTestCase;
+
+/**
+ * The tablet augment of the tabbox narrows the mold down to the two it can draw. It used to
+ * assign the narrowed mold without redrawing, so a mold pushed from the server left the DOM
+ * belonging to the previous mold: only the accordion mold wraps a tabpanel's cave in a
+ * -cave2, and getCaveNode() looks for exactly the node the mold says should be there.
+ *
+ * @author peakerlee
+ */
+@ForkJVMTestOnly
+public class B110_ZK_6090_TabboxMoldTest extends TabletWebDriverTestCase {
+
+	/** As drawn: the default mold, no -cave2, and a cave the panel can still find. */
+	private static final String DEFAULT_DOM = "default,plain,no-cave2,cave";
+	/** Redrawn in the accordion mold: the accordion class, a -cave2, and a cave again. */
+	private static final String ACCORDION_DOM = "accordion,accordion,cave2,cave";
+
+	/** A mold pushed from the server has to reach the DOM, not just the widget's field. */
+	@Test
+	public void testServerMoldPushRedraws() {
+		connect();
+		waitResponse();
+		assertPreconditions();
+
+		assertEquals(DEFAULT_DOM, getEval("window.zk6090Dom()"), "the page did not start in the default mold");
+
+		click(jq("$toAccordion"));
+		waitResponse();
+		sleep(500); // the touch molds rebind their gestures 300ms after the redraw
+		assertEquals(ACCORDION_DOM, getEval("window.zk6090Dom()"),
+				"the pushed mold must be redrawn, not only assigned");
+		assertNoError();
+
+		click(jq("$toDefault"));
+		waitResponse();
+		sleep(500);
+		assertEquals(DEFAULT_DOM, getEval("window.zk6090Dom()"), "switching back must redraw too");
+		assertNoError();
+	}
+
+	/**
+	 * accordion-lite is one of the molds the tablet augment maps onto accordion; the mapping
+	 * still has to redraw, and the widget must end up reporting the mold it actually drew.
+	 */
+	@Test
+	public void testMappedMoldPushRedraws() {
+		connect();
+		waitResponse();
+		assertPreconditions();
+
+		click(jq("$toAccordionLite"));
+		waitResponse();
+		sleep(500);
+		assertEquals(ACCORDION_DOM, getEval("window.zk6090Dom()"),
+				"accordion-lite must be mapped onto the accordion mold and redrawn");
+		assertNoError();
+	}
+
+	/**
+	 * Without the tablet UI the zkmax touch molds never load, the augment under test is not
+	 * installed at all, and every assertion below would pass on the plain CE widget.
+	 */
+	private void assertPreconditions() {
+		assertEquals("true", jq("$tabletUI").text(), "the tablet UI must be on");
+		assertEquals("true", jq("$touch").text(), "touch must be on");
+		// zk.Widget declares setMold, so only an own property proves the touch augment loaded
+		assertEquals("true", getEval("Object.prototype.hasOwnProperty.call("
+						+ "zul.tab.Tabbox.prototype, 'setMold')"),
+				"the touch augment for zul.tab.Tabbox must be installed");
+		assertEquals("true", getEval("'' + !!zul.tab.Tabbox.molds['accordion']"),
+				"the accordion mold must be on the client for a mold push to redraw");
+	}
+
+	private void assertNoError() {
+		assertEquals("", getEval("window.zk6090.errors.join('|')"), "the mold push threw");
+		assertNoJSError();
+	}
+}

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_TeardownTest.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_TeardownTest.java
@@ -1,0 +1,87 @@
+/* B110_ZK_6090_TeardownTest.java
+
+	Purpose:
+
+	Description:
+
+	History:
+		Fri Aug 21 14:50:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.util.Collections;
+import java.util.logging.Level;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.logging.LogType;
+
+import org.zkoss.test.webdriver.WebDriverTestCase;
+
+/**
+ * Two teardowns that used to leave something behind on a node they do not own: the fake
+ * scrollbars of a biglistbox put their wheel handlers on the body node, and the golden layout
+ * tab dropdown is moved into document.body while it is open.
+ *
+ * @author peakerlee
+ */
+public class B110_ZK_6090_TeardownTest extends WebDriverTestCase {
+
+	@Override
+	protected ChromeOptions getWebDriverOptions() {
+		ChromeOptions options = super.getWebDriverOptions();
+		// assertNoJSError() reads the browser console, which Chrome only exposes when asked for
+		options.setCapability("goog:loggingPrefs", Collections.singletonMap(LogType.BROWSER, Level.ALL));
+		return options;
+	}
+
+	/**
+	 * WScroll registers its wheel handler on the widget's body node, which survives
+	 * WScroll.destroy() — only the bar itself is removed.
+	 */
+	@Test
+	public void testWScrollWheelHandlers() {
+		connect();
+		waitResponse();
+		assertEquals("true", getEval("'' + !!window.zk6090.bodyNode"), "the biglistbox body should exist");
+		String bound = getEval("window.zk6090Wheel()");
+		assertNotEquals("0", bound,
+				"the fake scrollbars should have put wheel handlers on the body, events were "
+						+ getEval("window.zk6090Events(window.zk6090.bodyNode)"));
+
+		getEval("(window.zk6090Unbind('blb'), 1)");
+		assertEquals("0", getEval("window.zk6090Wheel()"),
+				"destroying the fake scrollbars must take their wheel handlers off the body,"
+						+ " they were bound as " + bound);
+		assertEquals("", getEval("window.zk6090.errors.join('|')"), "unbinding threw");
+		assertNoJSError();
+	}
+
+	/** The tab dropdown container is vparented into document.body while the dropdown is open. */
+	@Test
+	public void testGoldenLayoutDropdownVParent() {
+		connect();
+		waitResponse();
+		assertEquals("0", getEval("window.zk6090DropdownOrphans()"),
+				"nothing should sit in document.body before the dropdown is opened");
+
+		// the dropdown button only appears once the tabs overflow their stack header
+		assertEquals("true", getEval("'' + (jq('.lm_tabdropdown').length > 0)"),
+				"the tabs did not overflow, the dropdown button never appeared");
+		getEval("(jq('.lm_tabdropdown')[0].click(), 1)");
+		sleep(500);
+		assertEquals("1", getEval("window.zk6090DropdownOrphans()"),
+				"the open dropdown should have been moved into document.body");
+
+		getEval("(window.zk6090Unbind('gl'), 1)");
+		assertEquals("0", getEval("window.zk6090DropdownOrphans()"),
+				"unbinding the layout must take the dropdown back out of document.body");
+		assertEquals("", getEval("window.zk6090.errors.join('|')"), "unbinding threw");
+		assertNoJSError();
+	}
+}

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_TimerTest.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_TimerTest.java
@@ -1,0 +1,64 @@
+/* B110_ZK_6090_TimerTest.java
+
+	Purpose:
+
+	Description:
+
+	History:
+		Fri Aug 28 10:20:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Collections;
+import java.util.logging.Level;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.logging.LogType;
+
+import org.zkoss.test.webdriver.WebDriverTestCase;
+
+/**
+ * A repeating zul.utl.Timer registers a zAu error handler when it plays and has to
+ * unregister the very same one when it stops, otherwise every play/stop cycle piles
+ * one more up in zAu.
+ *
+ * @author peakerlee
+ */
+public class B110_ZK_6090_TimerTest extends WebDriverTestCase {
+
+	@Override
+	protected ChromeOptions getWebDriverOptions() {
+		ChromeOptions options = super.getWebDriverOptions();
+		// assertNoJSError() reads the browser console, which Chrome only exposes when asked for
+		options.setCapability("goog:loggingPrefs", Collections.singletonMap(LogType.BROWSER, Level.ALL));
+		return options;
+	}
+
+	@Test
+	public void test() {
+		connect();
+		waitResponse();
+
+		assertEquals("true", getEval("window.zk6090tm.patched"),
+				"the counting hook must be in place before the timer ever plays");
+		assertEquals("true/false", getEval("window.zk6090tm.state()"),
+				"a repeating timer that has not played yet");
+		assertEquals("0", getEval("window.zk6090tm.probe()"),
+				"a timer that never played must not have registered an error handler");
+
+		getEval("(window.zk6090tm.cycle(3), 1)");
+		assertEquals("true/true", getEval("window.zk6090tm.state()"),
+				"the timer must end up running, otherwise the last play never happened");
+		assertEquals("1", getEval("window.zk6090tm.probe()"),
+				"stopping the timer must unregister the handler it registered, otherwise "
+						+ "every play/stop cycle leaves one more behind in zAu");
+
+		assertEquals("", getEval("window.zk6090tm.errors.join('|')"), "the page threw");
+		assertNoJSError();
+	}
+}

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_TouchSwipeTest.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_TouchSwipeTest.java
@@ -1,0 +1,78 @@
+/* B110_ZK_6090_TouchSwipeTest.java
+
+	Purpose:
+
+	Description:
+
+	History:
+		Fri Aug 21 11:00:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import org.zkoss.test.webdriver.ForkJVMTestOnly;
+import org.zkoss.zktest.zats.TabletWebDriverTestCase;
+
+/**
+ * The zkmax touch molds give a calendar, a border layout region and a tab panel their own
+ * zk.Swipe, and each of them used to look the node up again while unbinding, after the
+ * widget had already lost it.
+ *
+ * @author peakerlee
+ */
+@ForkJVMTestOnly
+public class B110_ZK_6090_TouchSwipeTest extends TabletWebDriverTestCase {
+
+	@Test
+	public void test() {
+		connect();
+		waitResponse();
+
+		// without the tablet UI the zkmax touch molds never load and this test would
+		// exercise the plain CE hooks instead
+		assertEquals("true", jq("$tabletUI").text());
+		assertAugmented("zul.db.Calendar");
+		assertAugmented("zul.layout.LayoutRegion");
+		assertAugmented("zul.tab.Tabpanel");
+
+		sleep(1000); // the swipe is made 300ms after the widget is bound
+		for (String name : new String[] { "cal", "rgn", "tp" }) {
+			assertEquals("true", getEval("window.zk6090HasSwipe('" + name + "')"),
+					name + " should have got its zk.Swipe, otherwise nothing is tested");
+			getEval("(window.zk6090Unbind('" + name + "'), 1)");
+			assertEquals("false", getEval("window.zk6090HasSwipe('" + name + "')"),
+					name + " should have let its zk.Swipe go");
+		}
+		assertEquals("", getEval("window.zk6090.errors.join('|')"), "unbinding threw");
+		assertNoJSError();
+	}
+
+	/** The tablet mold of the chosenbox watches window for resize while it is bound. */
+	@Test
+	public void testChosenboxWindowResize() {
+		connect();
+		waitResponse();
+		assertEquals("true", jq("$tabletUI").text());
+		int before = Integer.parseInt(getEval("window.zk6090WindowResize()"));
+		assertTrue(before > 0, "the tablet chosenbox should watch window for resize");
+
+		getEval("(window.zk6090UnbindCbx(), 1)");
+		assertEquals(before - 1, Integer.parseInt(getEval("window.zk6090WindowResize()")),
+				"unbinding the chosenbox must take its window resize listener off");
+		assertEquals("", getEval("window.zk6090.errors.join('|')"), "unbinding threw");
+		assertNoJSError();
+	}
+
+	/** zk.Widget already declares the swipe hooks, so only an own property proves the augment loaded. */
+	private void assertAugmented(String widgetClass) {
+		assertEquals("true", getEval("Object.prototype.hasOwnProperty.call("
+						+ widgetClass + ".prototype, 'unbindSwipe_')"),
+				"the touch augment for " + widgetClass + " must be installed");
+	}
+}

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_TouchUnbindTest.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6090_TouchUnbindTest.java
@@ -1,0 +1,134 @@
+/* B110_ZK_6090_TouchUnbindTest.java
+
+	Purpose:
+
+	Description:
+
+	History:
+		Fri Aug 21 10:20:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.logging.Level;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.logging.LogType;
+
+import org.zkoss.test.webdriver.WebDriverTestCase;
+
+/**
+ * Unbinding a widget on a touch device has to undo whatever the touch gestures set up,
+ * including the parts that were only set up once a finger was already down.
+ *
+ * <p>The widgets are unbound from the client without touching the DOM, which is what a
+ * container doing render-on-demand does to its children: the node stays in the page, so
+ * anything left on it is counted instead of being thrown away with the node.
+ *
+ * @author peakerlee
+ */
+public class B110_ZK_6090_TouchUnbindTest extends WebDriverTestCase {
+
+	/** A plain desktop user agent: only the touch support is emulated, not a mobile device. */
+	private static final String DESKTOP_USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)"
+			+ " AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+	@Override
+	protected ChromeOptions getWebDriverOptions() {
+		ChromeOptions options = super.getWebDriverOptions();
+		// assertNoJSError() reads the browser console, which Chrome only exposes when asked for
+		options.setCapability("goog:loggingPrefs", Collections.singletonMap(LogType.BROWSER, Level.ALL));
+		return options.setExperimentalOption("mobileEmulation", Map.of(
+				"userAgent", DESKTOP_USER_AGENT,
+				"deviceMetrics", Map.of("width", 1280, "height", 900, "pixelRatio", 1, "touch", true)));
+	}
+
+	/**
+	 * zk.Swipe adds its move and end handlers only once the gesture has started, so
+	 * destroying it while a finger is down has to take those off as well.
+	 */
+	@Test
+	public void testUnbindDuringGesture() {
+		connectAndWaitForGestures();
+		assertEquals("touchstart", getEval("window.zk6090.startEvt"),
+				"zk.Swipe listens to mouse events here, the touch emulation did not take");
+		assertEquals("true", getEval("'' + !!window.zk6090.swiper._swipe"), "onSwipe should be bound");
+
+		String base = getEval("window.zk6090.swiperBase");
+		getEval("(window.zk6090Touch(window.zk6090.swiperNode, 'touchstart'), 1)");
+		String started = snap("swiper");
+		assertNotEquals(base, started, "the gesture should have added its move and end handlers");
+
+		getEval("(window.zk6090.swiper.unbind(), 1)");
+		assertEquals(base, snap("swiper"),
+				"destroying the swipe must take the in-flight gesture handlers off, they were " + started);
+
+		// a leftover move handler throws on the next finger move: destroy() already
+		// dropped the options it reads
+		getEval("(window.zk6090Touch(window.zk6090.swiperNode, 'touchmove'), 1)");
+		assertEquals("", getEval("window.zk6090.errors.join('|')"), "a leftover swipe handler threw");
+		assertNoJSError();
+	}
+
+	/**
+	 * The touch handlers were added because the widget had a listener; they still have to
+	 * come off once it no longer has one.
+	 */
+	@Test
+	public void testUnbindAfterListenersRemoved() {
+		connectAndWaitForGestures();
+		String base = getEval("window.zk6090.tapperBase");
+		String bound = snap("tapper");
+		assertNotEquals(base, bound, "the tap handlers should be on the node by now");
+
+		getEval("(window.zk6090Drop(), 1)");
+		assertEquals("false", getEval("'' + window.zk6090.tapper.isListen('onDoubleClick')"),
+				"the onDoubleClick listener should be gone");
+		assertEquals("false", getEval("'' + window.zk6090.tapper.isListen('onRightClick')"),
+				"the onRightClick listener should be gone");
+
+		getEval("(window.zk6090.tapper.unbind(), 1)");
+		assertEquals(base, snap("tapper"),
+				"unbinding must take the tap handlers off whether or not the listener is still there,"
+						+ " they were bound as " + bound);
+		assertNoJSError();
+	}
+
+	/**
+	 * A tap-hold that has already started arms an 800ms timer; unbinding has to cancel it,
+	 * or it delivers onRightClick to a widget that is no longer there.
+	 */
+	@Test
+	public void testUnbindCancelsPendingHold() {
+		connectAndWaitForGestures();
+		getEval("(window.zk6090Touch(window.zk6090.tapperNode, 'touchstart'), 1)");
+		assertEquals("true", getEval("'' + !!window.zk6090.tapper._rightClickPending"),
+				"the hold timer never started, nothing was tested");
+
+		getEval("(window.zk6090.tapper.unbind(), 1)");
+		sleep(1500); // the hold fires 800ms after the touch started
+		assertEquals("0", getEval("'' + window.zk6090.rightClicks"),
+				"a hold armed before the unbind fired onRightClick on an unbound widget");
+		assertEquals("", getEval("window.zk6090.errors.join('|')"), "the pending hold threw");
+		assertNoJSError();
+	}
+
+	private void connectAndWaitForGestures() {
+		connect();
+		waitResponse();
+		assertEquals("true", getEval("String(navigator.maxTouchPoints > 0)"), "touch should be emulated");
+		assertEquals("true", getEval("String(!!zk.touchEnabled)"), "zk.touchEnabled should be on");
+		sleep(1000); // the touch handlers are added 300ms after the widget is bound
+	}
+
+	private String snap(String which) {
+		return getEval("window.zk6090Snap(window.zk6090." + which + "Node)");
+	}
+}

--- a/zul/src/main/resources/web/js/zul/WScroll.ts
+++ b/zul/src/main/resources/web/js/zul/WScroll.ts
@@ -412,18 +412,18 @@ export class WScroll extends zk.Object {
 	_listenMouseEvent(): void {
 		if (this._isVer) {
 			// @ts-expect-error: zk.Event is not completely compatible with JQueryMousewheelEventObject
-			jq(this.control).mousewheel(this._mousewheelY.bind(this));
+			jq(this.control).mousewheel(this.proxy(this._mousewheelY));
 		} else if (!zk.opera) { // ie and opera unsupported
 			// @ts-expect-error: zk.Event is not completely compatible with JQueryMousewheelEventObject
-			jq(this.control).mousewheel(this._mousewheelX.bind(this));
+			jq(this.control).mousewheel(this.proxy(this._mousewheelX));
 		}
 
 		var $drag = jq(this.edrag);
 		$drag.children('div')
-			.on('mouseover', this._mouseOver.bind(this))
-			.on('mouseout', this._mouseOut.bind(this))
-			.on('mouseup', this._mouseUp.bind(this))
-			.on('mousedown', this._mouseDown.bind(this));
+			.on('mouseover', this.proxy(this._mouseOver))
+			.on('mouseout', this.proxy(this._mouseOut))
+			.on('mouseup', this.proxy(this._mouseUp))
+			.on('mousedown', this.proxy(this._mouseDown));
 		$drag.on('click', zk.$void);
 	}
 
@@ -431,17 +431,17 @@ export class WScroll extends zk.Object {
 	_unlistenMouseEvent(): void {
 		if (this._isVer)
 			// @ts-expect-error: unmousewheel expects 0 arguments, but got 1
-			jq(this.control).unmousewheel(this._mousewheelY.bind(this));
+			jq(this.control).unmousewheel(this.proxy(this._mousewheelY));
 		else if (!zk.opera) // ie and opera unsupported
 			// @ts-expect-error: unmousewheel expects 0 arguments, but got 1
-			jq(this.control).unmousewheel(this._mousewheelX.bind(this));
+			jq(this.control).unmousewheel(this.proxy(this._mousewheelX));
 
 		var $drag = jq(this.edrag);
 		$drag.children('div')
-			.off('mouseover', this._mouseOver.bind(this))
-			.off('mouseout', this._mouseOut.bind(this))
-			.off('mouseup', this._mouseUp.bind(this))
-			.off('mousedown', this._mouseDown.bind(this));
+			.off('mouseover', this.proxy(this._mouseOver))
+			.off('mouseout', this.proxy(this._mouseOut))
+			.off('mouseup', this.proxy(this._mouseUp))
+			.off('mousedown', this.proxy(this._mouseDown));
 		$drag.off('click', zk.$void);
 	}
 

--- a/zul/src/main/resources/web/js/zul/db/Timebox.ts
+++ b/zul/src/main/resources/web/js/zul/db/Timebox.ts
@@ -735,6 +735,9 @@ export class Timebox extends zul.inp.FormatWidget<DateImpl> {
 			this.timerId = undefined;
 		}
 		zWatch.unlisten({onSize: this});
+		// the listener lives on the body, it has to go even if the button never came up
+		this.domUnlisten_(document.body, 'onZMouseup', '_ondropbtnup');
+		this._currentbtn = undefined;
 		var btn = this.$n('btn');
 		if (btn) {
 			this.domUnlisten_(btn, 'onZMouseDown', '_btnDown')

--- a/zul/src/main/resources/web/js/zul/inp/Bandpopup.ts
+++ b/zul/src/main/resources/web/js/zul/inp/Bandpopup.ts
@@ -32,16 +32,17 @@ export class Bandpopup extends zul.Widget {
 	/** @internal */
 	override bind_(desktop?: zk.Desktop, skipper?: zk.Skipper, after?: CallableFunction[]): void {
 		super.bind_(desktop, skipper, after);
+		// proxy() caches the bound function, so unbind_ can take the very same one off again
 		jq(this.$n())
-			.on('focusin', this._focusin.bind(this))
-			.on('focusout', this._focusout.bind(this));
+			.on('focusin', this.proxy(this._focusin))
+			.on('focusout', this.proxy(this._focusout));
 	}
 
 	/** @internal */
 	override unbind_(skipper?: zk.Skipper, after?: CallableFunction[], keepRod?: boolean): void {
 		jq(this.$n())
-			.off('focusout', this._focusout.bind(this))
-			.off('focusin', this._focusin.bind(this));
+			.off('focusout', this.proxy(this._focusout))
+			.off('focusin', this.proxy(this._focusin));
 		super.unbind_(skipper, after, keepRod);
 	}
 

--- a/zul/src/main/resources/web/js/zul/inp/Doublespinner.ts
+++ b/zul/src/main/resources/web/js/zul/inp/Doublespinner.ts
@@ -386,6 +386,9 @@ export class Doublespinner extends zul.inp.NumberInputWidget<number> {
 			this.timerId = undefined;
 		}
 		zWatch.unlisten({onSize: this});
+		// the listener lives on the body, it has to go even if the button never came up
+		this.domUnlisten_(document.body, 'onZMouseup', '_ondropbtnup');
+		this._currentbtn = undefined;
 		var btn = this.$n('btn');
 		if (btn)
 			this.domUnlisten_(btn, 'onZMouseDown', '_btnDown')

--- a/zul/src/main/resources/web/js/zul/inp/Slider.ts
+++ b/zul/src/main/resources/web/js/zul/inp/Slider.ts
@@ -684,10 +684,8 @@ export class Slider extends zul.Widget {
 
 	/** @internal */
 	override unbind_(skipper?: zk.Skipper, after?: CallableFunction[], keepRod?: boolean): void {
-		if (this._mold == 'knob') {
-			super.unbind_(skipper, after, keepRod);
-			return;
-		}
+		// not gated on _mold: setMold() assigns _mold before it rerenders, so a
+		// switch to the knob mold would otherwise skip the whole teardown below
 		this.efield = undefined;
 		if (this._drag) {
 			this._drag.destroy();

--- a/zul/src/main/resources/web/js/zul/inp/Spinner.ts
+++ b/zul/src/main/resources/web/js/zul/inp/Spinner.ts
@@ -301,6 +301,9 @@ export class Spinner extends zul.inp.NumberInputWidget<number> {
 			this.timerId = undefined;
 		}
 		zWatch.unlisten({onSize: this});
+		// the listener lives on the body, it has to go even if the button never came up
+		this.domUnlisten_(document.body, 'onZMouseup', '_ondropbtnup');
+		this._currentbtn = undefined;
 		var btn = this.$n('btn');
 		if (btn)
 			this.domUnlisten_(btn, 'onZMouseDown', '_btnDown')

--- a/zul/src/main/resources/web/js/zul/layout/LayoutRegion.ts
+++ b/zul/src/main/resources/web/js/zul/layout/LayoutRegion.ts
@@ -809,6 +809,11 @@ export class LayoutRegion extends zul.Widget {
 			}
 		}
 
+		// both flags, or the next binding is drawn collapsed while setSlide() still
+		// short-circuits on the old value and slides the region the wrong way
+		jq(document).off('click', this.proxy(this._docClick));
+		this._isSlide = this._slide = false;
+
 		this.destroyBar_();
 
 		if (this.$n('split')) {

--- a/zul/src/main/resources/web/js/zul/menu/Menu.ts
+++ b/zul/src/main/resources/web/js/zul/menu/Menu.ts
@@ -652,6 +652,8 @@ export class ContentHandler extends zk.Object {
 	_shadow?: zk.eff.Shadow;
 	/** @internal */
 	_pp?: HTMLElement;
+	/** The node bind() listened to, or nothing if it made no registration. @internal */
+	_listenedNode?: HTMLElement;
 
 	constructor(wgt: zul.menu.Menu, content: string) {
 		super();
@@ -677,7 +679,8 @@ export class ContentHandler extends zk.Object {
 	bind(): void {
 		var wgt = this._wgt;
 		if (!wgt.menupopup) {
-			wgt.domListen_(wgt.$n_(), 'onClick', 'onShow');
+			this._listenedNode = wgt.$n_();
+			wgt.domListen_(this._listenedNode, 'onClick', 'onShow');
 			zWatch.listen({onFloatUp: wgt, onHide: wgt});
 		}
 
@@ -690,13 +693,21 @@ export class ContentHandler extends zk.Object {
 
 	unbind(): void {
 		var wgt = this._wgt;
-		if (!wgt.menupopup) {
-			if (this._shadow) {
-				this._shadow.destroy();
-				this._shadow = undefined;
-			}
-			wgt.domUnlisten_(wgt.$n_(), 'onClick', 'onShow');
+		// onShow vparented -cnt-pp into document.body; _pp is dropped below, so this is the
+		// last chance to bring it back - otherwise it is orphaned there, still visible
+		this.onHide();
+		// the shadow is made whatever the menu carries, so it has to go the same way
+		if (this._shadow) {
+			this._shadow.destroy();
+			this._shadow = undefined;
+		}
+		// release what bind() took: onChildAdded_ sets menupopup before it rerenders, so
+		// re-testing it here reads a state bind() never saw and skips the release for good
+		var listened = this._listenedNode;
+		if (listened) {
+			wgt.domUnlisten_(listened, 'onClick', 'onShow');
 			zWatch.unlisten({onFloatUp: wgt, onHide: wgt});
+			this._listenedNode = undefined;
 		}
 
 		jq(this._pp, zk)

--- a/zul/src/main/resources/web/js/zul/mesh/Frozen.ts
+++ b/zul/src/main/resources/web/js/zul/mesh/Frozen.ts
@@ -77,6 +77,10 @@ export class Frozen extends zul.Widget {
 	/** @internal */
 	_delayedScroll?: number;
 	/** @internal */
+	_delayedSize?: number;
+	/** Handle of the sizing timer the smooth onSize schedules. @internal */
+	_delayedSmoothSize?: number;
+	/** @internal */
 	_lastScale?: number;
 	/** @internal */
 	_shallSync?: boolean;
@@ -340,6 +344,19 @@ export class Frozen extends zul.Widget {
 			jq(this.parent?.$n('body')).css('scrollbar-width', '');
 		this._clearColumnBorders();
 
+		// these sizing timers reach the DOM, so they must not outlive the binding.
+		// _delayedScroll is deliberately NOT cancelled here: it also carries the
+		// smartUpdate('start') of a scroll the user already made, which a rerender
+		// in the same tick would otherwise swallow. Its body checks desktop instead.
+		if (this._delayedSmoothSize) {
+			clearTimeout(this._delayedSmoothSize);
+			this._delayedSmoothSize = undefined;
+		}
+		if (this._delayedSize) {
+			clearTimeout(this._delayedSize);
+			this._delayedSize = undefined;
+		}
+
 		var p = this.parent!,
 			body = p.$n('body'),
 			foot = p.$n('foot'),
@@ -399,7 +416,14 @@ export class Frozen extends zul.Widget {
 				}
 			}
 		}
-		setTimeout(() => {
+		if (this._delayedSmoothSize)
+			clearTimeout(this._delayedSmoothSize);
+		this._delayedSmoothSize = setTimeout(() => {
+			this._delayedSmoothSize = undefined;
+			//unbind_ cancels this timer, but _unbindrod() drops a widget through
+			//_unbind0() alone and never runs unbind_, so it can still get here
+			if (!this.desktop)
+				return;
 			this._freezeRightColumns();
 			this._onSizeLater();
 		});
@@ -430,7 +454,14 @@ export class Frozen extends zul.Widget {
 		}
 
 		// Bug 3218078, to do the sizing after the 'setAttr' command
-		setTimeout(() => {
+		if (this._delayedSize)
+			clearTimeout(this._delayedSize);
+		this._delayedSize = setTimeout(() => {
+			this._delayedSize = undefined;
+			//unbind_ cancels this timer, but _unbindrod() drops a widget through
+			//_unbind0() alone and never runs unbind_, so it can still get here
+			if (!this.desktop)
+				return;
 			_onSizeLater(this);
 			this._syncFrozenNow();
 		});
@@ -518,11 +549,15 @@ export class Frozen extends zul.Widget {
 				clearTimeout(this._delayedScroll);
 			}
 			this._delayedScroll = setTimeout(() => {
+				this._delayedScroll = undefined;
+				//survives a rerender on purpose (unbind_ leaves it alone) so the
+				//scroll still reaches the server, but never touches a dead widget
+				if (!this.desktop)
+					return;
 				this._lastScale = num;
 				this._doScrollNow(num);
 				this.smartUpdate('start', num);
 				this._start = num;
-				this._delayedScroll = undefined;
 			}, 0);
 			return;
 		}

--- a/zul/src/main/resources/web/js/zul/utl/Timer.ts
+++ b/zul/src/main/resources/web/js/zul/utl/Timer.ts
@@ -147,7 +147,8 @@ export class Timer extends zk.Widget {
 			delete this._tid;
 			clearTimeout(id);
 		}
-		zAu.unError(this._onErr.bind(this));
+		//must be the same identity _play() registered, or unError() matches nothing
+		zAu.unError(this.proxy(this._onErr));
 	}
 
 	/** @internal */

--- a/zul/src/main/resources/web/js/zul/wgt/Toolbar.ts
+++ b/zul/src/main/resources/web/js/zul/wgt/Toolbar.ts
@@ -171,6 +171,8 @@ export class Toolbar extends zul.Widget {
 	override unbind_(skipper?: zk.Skipper, after?: CallableFunction[], keepRod?: boolean): void {
 		const popup = this.$n('pp');
 		if (popup) {
+			// _openPopup vparents -pp into document.body and only onFloatUp undoes it
+			this._closePopup();
 			this.domUnlisten_(this.$n_('overflowpopup-button'), 'onClick', '_openPopup');
 			zWatch.unlisten({ onFloatUp: this, onCommandReady: this, onSize: this });
 		}


### PR DESCRIPTION
Please merge this alongside https://github.com/zkoss/zkcml/pull/1343.