### PR TITLE
Decouple WebDriver tests from hardcoded Selenium CDP version

### DIFF
--- a/zktest/build.gradle
+++ b/zktest/build.gradle
@@ -138,8 +138,6 @@ dependencies {
 	testImplementation 'xml-apis:xml-apis:1.4.01'
 	testImplementation 'org.zkoss.test:zk-webdriver:1.4.39.0.2'
 
-	// For B96_ZK_4194Test and F102_ZK_5461Test to use a specific Chrome driver version (this will change to match latest chrome)
-	testImplementation 'org.seleniumhq.selenium:selenium-devtools-v143:4.39.0'
 	testImplementation "org.seleniumhq.selenium:selenium-java:4.39.0"
 	testImplementation 'com.google.javascript:closure-compiler-unshaded:v20230802'
 

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B103_ZK_6055Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B103_ZK_6055Test.java
@@ -13,18 +13,12 @@ package org.zkoss.zktest.zats.test2;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.openqa.selenium.chrome.ChromeDriver;
-import org.openqa.selenium.devtools.DevTools;
-import org.openqa.selenium.devtools.v142.network.Network;
-import org.openqa.selenium.devtools.v142.network.model.Response;
 
 import org.zkoss.test.webdriver.ExternalZkXml;
 import org.zkoss.test.webdriver.ForkJVMTestOnly;
@@ -37,57 +31,27 @@ public class B103_ZK_6055Test extends WebDriverTestCase {
     private static final String test_page = "/test2/B103-ZK-6055.zul";
 
     @Test
-    public void test() {
-        connect();
-        DevTools devTools = ((ChromeDriver) driver).getDevTools();
-        devTools.createSession();
-
-        devTools.send(Network.enable(
-                Optional.empty(),
-                Optional.empty(),
-                Optional.empty(),
-                Optional.empty(),
-                Optional.empty()
-        ));
-
-        AtomicReference<String> cspHeaderRef = new AtomicReference<>();
-        AtomicReference<String> cspReportOnlyRef = new AtomicReference<>();
-        CountDownLatch latch = new CountDownLatch(1);
-
-        devTools.addListener(Network.responseReceived(), response -> {
-            Response resp = response.getResponse();
-
-            if (resp.getUrl().contains(test_page)) {
-                Map<String, Object> headers = resp.getHeaders().toJson();
-                Object csp = headers.get("Content-Security-Policy");
-                Object cspReportOnly = headers.get("Content-Security-Policy-Report-Only");
-
-                cspHeaderRef.set(csp != null ? csp.toString() : null);
-                cspReportOnlyRef.set(cspReportOnly != null ? cspReportOnly.toString() : null);
-                latch.countDown();
-            }
-        });
-        driver.get(getAddress() + test_page);
-        waitResponse();
-
-        click(jq("@nav"));
-        waitResponse();
-
+    public void test() throws IOException {
+        HttpURLConnection conn = (HttpURLConnection) new URL(getAddress() + test_page).openConnection();
+        conn.setRequestMethod("GET");
+        conn.connect();
         try {
-            assertTrue(latch.await(10, TimeUnit.SECONDS));
-
-            assertNotNull(cspHeaderRef.get());
-            assertNull(cspReportOnlyRef.get());
-
-            String cspHeader = cspHeaderRef.get();
+            String cspHeader = conn.getHeaderField("Content-Security-Policy");
+            assertNotNull(cspHeader);
+            assertNull(conn.getHeaderField("Content-Security-Policy-Report-Only"));
             assertTrue(cspHeader.contains("script-src"));
             assertTrue(cspHeader.contains("'self'"));
             assertTrue(cspHeader.contains("'strict-dynamic'"));
             assertTrue(cspHeader.contains("'unsafe-inline'"));
             assertTrue(cspHeader.contains("'unsafe-eval'"));
             assertTrue(cspHeader.contains("'unsafe-hashes'"));
-            assertNoJSError();
-        } catch (InterruptedException ignored) {
+        } finally {
+            conn.disconnect();
         }
+
+        connect(test_page);
+        click(jq("@nav"));
+        waitResponse();
+        assertNoJSError();
     }
 }

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B96_ZK_4194Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B96_ZK_4194Test.java
@@ -13,15 +13,13 @@ package org.zkoss.zktest.zats.test2;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.Optional;
+import java.time.Duration;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
-import org.openqa.selenium.devtools.DevTools;
-import org.openqa.selenium.devtools.v143.network.Network;
-import org.openqa.selenium.devtools.v143.network.model.ConnectionType;
+import org.openqa.selenium.chromium.ChromiumNetworkConditions;
 
 import org.zkoss.test.webdriver.ChromiumHeadlessDriver;
 import org.zkoss.test.webdriver.ExternalZkXml;
@@ -39,6 +37,15 @@ public class B96_ZK_4194Test extends WebDriverTestCase {
 
 	protected boolean isUsingRemoteWebDriver(ChromeOptions driverOptions) {
 		return false;
+	}
+
+	private static ChromiumNetworkConditions offlineConditions() {
+		ChromiumNetworkConditions conditions = new ChromiumNetworkConditions();
+		conditions.setOffline(true);
+		conditions.setLatency(Duration.ofMillis(20));
+		conditions.setDownloadThroughput(20);
+		conditions.setUploadThroughput(40);
+		return conditions;
 	}
 
 	@Test
@@ -59,14 +66,8 @@ public class B96_ZK_4194Test extends WebDriverTestCase {
 		_local.set(window1);
 		assertEquals(1, jq("$eventLog @label").length());
 
-		try (DevTools devTools = window1.getDevTools()) {
-			devTools.createSession();
-			// network offline
-			devTools.send(
-					Network.enable(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()));
-			devTools.send(Network.emulateNetworkConditions(true, 20, 20, 40,
-					Optional.of(ConnectionType.WIFI), Optional.empty(), Optional.empty(), Optional.empty()));
-
+		window1.setNetworkConditions(offlineConditions());
+		try {
 			_local.set(window2);
 			for (int i = 0; i < 9; i++) {
 				click(jq("@button"));
@@ -77,7 +78,8 @@ public class B96_ZK_4194Test extends WebDriverTestCase {
 
 			_local.set(window1);
 			assertEquals(1, jq("$eventLog @label").length());
-
+		} finally {
+			window1.deleteNetworkConditions();
 		}
 
 		click(jq("@button"));
@@ -105,15 +107,8 @@ public class B96_ZK_4194Test extends WebDriverTestCase {
 		_local.set(window1);
 		assertEquals(1, jq("$eventLog @label").length());
 
-		try (DevTools devTools = window1.getDevTools()) {
-			devTools.createSession();
-			// network offline
-			devTools.send(Network.enable(Optional.empty(), Optional.empty(),
-					Optional.empty(), Optional.empty(), Optional.empty()));
-			devTools.send(Network.emulateNetworkConditions(true, 20, 20, 40,
-					Optional.of(ConnectionType.WIFI),Optional.empty(), Optional.empty(),
-					Optional.empty()));
-
+		window1.setNetworkConditions(offlineConditions());
+		try {
 			_local.set(window2);
 			for (int i = 0; i < 19; i++) {
 				click(jq("@button"));
@@ -124,7 +119,8 @@ public class B96_ZK_4194Test extends WebDriverTestCase {
 
 			_local.set(window1);
 			assertEquals(1, jq("$eventLog @label").length());
-
+		} finally {
+			window1.deleteNetworkConditions();
 		}
 
 		click(jq("@button"));
@@ -152,15 +148,8 @@ public class B96_ZK_4194Test extends WebDriverTestCase {
 		_local.set(window1);
 		assertEquals(1, jq("$eventLog @label").length());
 
-		try (DevTools devTools = window1.getDevTools()) {
-			devTools.createSession();
-			// network offline
-			devTools.send(Network.enable(Optional.empty(), Optional.empty(),
-					Optional.empty(), Optional.empty(), Optional.empty()));
-			devTools.send(Network.emulateNetworkConditions(true, 20, 20, 40,
-					Optional.of(ConnectionType.WIFI),Optional.empty(), Optional.empty(),
-					Optional.empty()));
-
+		window1.setNetworkConditions(offlineConditions());
+		try {
 			_local.set(window2);
 			for (int i = 0; i < 19; i++) {
 				click(jq("@button"));
@@ -171,7 +160,8 @@ public class B96_ZK_4194Test extends WebDriverTestCase {
 
 			_local.set(window1);
 			assertEquals(1, jq("$eventLog @label").length());
-
+		} finally {
+			window1.deleteNetworkConditions();
 		}
 
 		sleep(60_000); // wait for 1 minute to timeout

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/F102_ZK_5461Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/F102_ZK_5461Test.java
@@ -13,28 +13,34 @@ package org.zkoss.zktest.zats.test2;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.chrome.ChromeDriver;
-import org.openqa.selenium.devtools.DevTools;
-import org.openqa.selenium.devtools.v143.network.Network;
+import org.openqa.selenium.bidi.module.Network;
+import org.openqa.selenium.chrome.ChromeOptions;
 
 import org.zkoss.test.webdriver.WebDriverTestCase;
 
 public class F102_ZK_5461Test extends WebDriverTestCase {
+	@Override
+	protected ChromeOptions getWebDriverOptions() {
+		ChromeOptions options = super.getWebDriverOptions();
+		options.setCapability("webSocketUrl", true);
+		return options;
+	}
+
 	@Test
 	public void test() {
 		connect();
-		Map<String, Object> headers = new HashMap<>();
-		DevTools devTools = ((ChromeDriver) driver).getDevTools();
-		devTools.createSession();
-		devTools.send(Network.enable(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()));
-		devTools.addListener(Network.requestWillBeSent(), request -> headers.putAll(request.getRequest().getHeaders()));
-		click(jq("@button"));
-		waitResponse();
+		Map<String, String> headers = new ConcurrentHashMap<>();
+		try (Network network = new Network(driver)) {
+			network.onBeforeRequestSent(args ->
+					args.getRequest().getHeaders().forEach(h ->
+							headers.put(h.getName(), h.getValue().getValue())));
+			click(jq("@button"));
+			waitResponse();
+		}
 		assertEquals("myValue", headers.get("myKey"));
 	}
 }

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/F103_ZK_5265DynamicTest.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/F103_ZK_5265DynamicTest.java
@@ -13,18 +13,12 @@ package org.zkoss.zktest.zats.test2;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.openqa.selenium.chrome.ChromeDriver;
-import org.openqa.selenium.devtools.DevTools;
-import org.openqa.selenium.devtools.v143.network.Network;
-import org.openqa.selenium.devtools.v143.network.model.Response;
 
 import org.zkoss.test.webdriver.ExternalZkXml;
 import org.zkoss.test.webdriver.ForkJVMTestOnly;
@@ -49,53 +43,22 @@ public class F103_ZK_5265DynamicTest extends WebDriverTestCase {
 	}
 
 	@Test
-	public void testHeader() {
-		connect();
-		DevTools devTools = ((ChromeDriver) driver).getDevTools();
-		devTools.createSession();
-
-		devTools.send(Network.enable(
-				Optional.empty(),
-				Optional.empty(),
-				Optional.empty(),
-				Optional.empty(),
-				Optional.empty()
-		));
-
-		AtomicReference<String> cspHeaderRef = new AtomicReference<>();
-		AtomicReference<String> cspReportOnlyRef = new AtomicReference<>();
-		CountDownLatch latch = new CountDownLatch(1);
-
-		devTools.addListener(Network.responseReceived(), response -> {
-			Response resp = response.getResponse();
-
-			if (resp.getUrl().contains(test_page)) {
-				Map<String, Object> headers = resp.getHeaders().toJson();
-				Object csp = headers.get("Content-Security-Policy");
-				Object cspReportOnly = headers.get("Content-Security-Policy-Report-Only");
-
-				cspHeaderRef.set(csp != null ? csp.toString() : null);
-				cspReportOnlyRef.set(cspReportOnly != null ? cspReportOnly.toString() : null);
-				latch.countDown();
-			}
-		});
-		driver.get(getAddress() + test_page);
-		waitResponse();
-
+	public void testHeader() throws IOException {
+		HttpURLConnection conn = (HttpURLConnection) new URL(getAddress() + test_page).openConnection();
+		conn.setRequestMethod("GET");
+		conn.connect();
 		try {
-			assertTrue(latch.await(10, TimeUnit.SECONDS));
-
-			assertNotNull(cspHeaderRef.get());
-			assertNull(cspReportOnlyRef.get());
-
-			String cspHeader = cspHeaderRef.get();
+			String cspHeader = conn.getHeaderField("Content-Security-Policy");
+			assertNotNull(cspHeader);
+			assertNull(conn.getHeaderField("Content-Security-Policy-Report-Only"));
 			assertTrue(cspHeader.contains("script-src"));
 			assertTrue(cspHeader.contains("'self'"));
 			assertTrue(cspHeader.contains("'strict-dynamic'"));
 			assertTrue(cspHeader.contains("'unsafe-inline'"));
 			assertTrue(cspHeader.contains("'unsafe-eval'"));
 			assertTrue(cspHeader.contains("'nonce-"));
-		} catch (InterruptedException ignored) {
+		} finally {
+			conn.disconnect();
 		}
 	}
 

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/F103_ZK_5265EnabledTest.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/F103_ZK_5265EnabledTest.java
@@ -15,18 +15,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.openqa.selenium.chrome.ChromeDriver;
-import org.openqa.selenium.devtools.DevTools;
-import org.openqa.selenium.devtools.v143.network.Network;
-import org.openqa.selenium.devtools.v143.network.model.Response;
 
 import org.zkoss.test.webdriver.ExternalZkXml;
 import org.zkoss.test.webdriver.ForkJVMTestOnly;
@@ -39,51 +33,19 @@ public class F103_ZK_5265EnabledTest extends WebDriverTestCase {
 	private static final String test_page = "/test2/F103-ZK-5265Enabled.zul";
 
 	@Test
-	public void testHeader() {
-		connect();
-		DevTools devTools = ((ChromeDriver) driver).getDevTools();
-		devTools.createSession();
-
-		devTools.send(Network.enable(
-				Optional.empty(),
-				Optional.empty(),
-				Optional.empty(),
-				Optional.empty(),
-				Optional.empty()
-		));
-
-		AtomicReference<String> cspHeaderRef = new AtomicReference<>();
-		AtomicReference<String> cspReportOnlyRef = new AtomicReference<>();
-		CountDownLatch latch = new CountDownLatch(1);
-
-		devTools.addListener(Network.responseReceived(), response -> {
-			Response resp = response.getResponse();
-
-			if (resp.getUrl().contains(test_page)) {
-				Map<String, Object> headers = resp.getHeaders().toJson();
-				Object csp = headers.get("Content-Security-Policy");
-				Object cspReportOnly = headers.get("Content-Security-Policy-Report-Only");
-
-				cspHeaderRef.set(csp != null ? csp.toString() : null);
-				cspReportOnlyRef.set(cspReportOnly != null ? cspReportOnly.toString() : null);
-				latch.countDown();
-			}
-		});
-
-		driver.get(getAddress() + test_page);
-		waitResponse();
-
+	public void testHeader() throws IOException {
+		HttpURLConnection conn = (HttpURLConnection) new URL(getAddress() + test_page).openConnection();
+		conn.setRequestMethod("GET");
+		conn.connect();
 		try {
-			assertTrue(latch.await(5, TimeUnit.SECONDS));
-			assertNotNull(cspHeaderRef.get());
-			assertNull(cspReportOnlyRef.get());
-
-			String cspHeader = cspHeaderRef.get();
+			String cspHeader = conn.getHeaderField("Content-Security-Policy");
+			assertNotNull(cspHeader);
+			assertNull(conn.getHeaderField("Content-Security-Policy-Report-Only"));
 			assertTrue(cspHeader.contains("script-src"));
 			assertTrue(cspHeader.contains("'unsafe-eval'"));
 			assertTrue(cspHeader.contains("'unsafe-inline'"));
-			driver.quit();
-		} catch (InterruptedException ignored) {
+		} finally {
+			conn.disconnect();
 		}
 	}
 

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/F103_ZK_5265GeneratorTest.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/F103_ZK_5265GeneratorTest.java
@@ -13,18 +13,12 @@ package org.zkoss.zktest.zats.test2;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.openqa.selenium.chrome.ChromeDriver;
-import org.openqa.selenium.devtools.DevTools;
-import org.openqa.selenium.devtools.v143.network.Network;
-import org.openqa.selenium.devtools.v143.network.model.Response;
 
 import org.zkoss.test.webdriver.ExternalZkXml;
 import org.zkoss.test.webdriver.ForkJVMTestOnly;
@@ -37,49 +31,16 @@ public class F103_ZK_5265GeneratorTest extends WebDriverTestCase {
 	private static final String test_page = "/test2/F103-ZK-5265Generator.zul";
 
 	@Test
-	public void testHeader() {
-		connect();
-		DevTools devTools = ((ChromeDriver) driver).getDevTools();
-		devTools.createSession();
-
-		devTools.send(Network.enable(
-				Optional.empty(),
-				Optional.empty(),
-				Optional.empty(),
-				Optional.empty(),
-				Optional.empty()
-		));
-
-		AtomicReference<String> cspHeaderRef = new AtomicReference<>();
-		AtomicReference<String> cspReportOnlyRef = new AtomicReference<>();
-		CountDownLatch latch = new CountDownLatch(1);
-
-		devTools.addListener(Network.responseReceived(), response -> {
-			Response resp = response.getResponse();
-
-			if (resp.getUrl().endsWith(test_page)) {
-				Map<String, Object> headers = resp.getHeaders().toJson();
-				Object csp = headers.get("Content-Security-Policy");
-				Object cspReportOnly = headers.get("Content-Security-Policy-Report-Only");
-
-				cspHeaderRef.set(csp != null ? csp.toString() : null);
-				cspReportOnlyRef.set(cspReportOnly != null ? cspReportOnly.toString() : null);
-				latch.countDown();
-			}
-		});
-
-		driver.get(getAddress() + test_page);
-		waitResponse();
-
+	public void testHeader() throws IOException {
+		HttpURLConnection conn = (HttpURLConnection) new URL(getAddress() + test_page).openConnection();
+		conn.setRequestMethod("GET");
+		conn.connect();
 		try {
-			assertTrue(latch.await(5, TimeUnit.SECONDS));
-			assertNotNull(cspHeaderRef.get());
-			assertNull(cspReportOnlyRef.get());
-
-			String cspHeader = cspHeaderRef.get();
+			String cspHeader = conn.getHeaderField("Content-Security-Policy");
 			assertNotNull(cspHeader);
-			driver.quit();
-		} catch (InterruptedException ignored) {
+			assertNull(conn.getHeaderField("Content-Security-Policy-Report-Only"));
+		} finally {
+			conn.disconnect();
 		}
 	}
 

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/F103_ZK_5265MultiPolicyTest.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/F103_ZK_5265MultiPolicyTest.java
@@ -13,18 +13,12 @@ package org.zkoss.zktest.zats.test2;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.openqa.selenium.chrome.ChromeDriver;
-import org.openqa.selenium.devtools.DevTools;
-import org.openqa.selenium.devtools.v143.network.Network;
-import org.openqa.selenium.devtools.v143.network.model.Response;
 
 import org.zkoss.test.webdriver.ExternalZkXml;
 import org.zkoss.test.webdriver.ForkJVMTestOnly;
@@ -49,45 +43,15 @@ public class F103_ZK_5265MultiPolicyTest extends WebDriverTestCase {
 	}
 
 	@Test
-	public void testHeader() {
-		connect();
-		DevTools devTools = ((ChromeDriver) driver).getDevTools();
-		devTools.createSession();
-
-		devTools.send(Network.enable(
-				Optional.empty(),
-				Optional.empty(),
-				Optional.empty(),
-				Optional.empty(),
-				Optional.empty()
-		));
-
-		AtomicReference<String> cspHeaderRef = new AtomicReference<>();
-		AtomicReference<String> cspReportOnlyRef = new AtomicReference<>();
-		CountDownLatch latch = new CountDownLatch(1);
-
-		devTools.addListener(Network.responseReceived(), response -> {
-			Response resp = response.getResponse();
-			if (resp.getUrl().endsWith(test_page)) {
-				Map<String, Object> headers = resp.getHeaders().toJson();
-				Object csp = headers.get("Content-Security-Policy");
-				Object cspReportOnly = headers.get("Content-Security-Policy-Report-Only");
-
-				cspHeaderRef.set(csp != null ? csp.toString() : null);
-				cspReportOnlyRef.set(cspReportOnly != null ? cspReportOnly.toString() : null);
-				latch.countDown();
-			}
-		});
-
-		driver.get(getAddress() + test_page);
-		waitResponse();
-
+	public void testHeader() throws IOException {
+		HttpURLConnection conn = (HttpURLConnection) new URL(getAddress() + test_page).openConnection();
+		conn.setRequestMethod("GET");
+		conn.connect();
 		try {
-			assertTrue(latch.await(10, TimeUnit.SECONDS));
-			assertNotNull(cspHeaderRef.get());
-			assertNull(cspReportOnlyRef.get());
+			String cspHeader = conn.getHeaderField("Content-Security-Policy");
+			assertNotNull(cspHeader);
+			assertNull(conn.getHeaderField("Content-Security-Policy-Report-Only"));
 
-			String cspHeader = cspHeaderRef.get();
 			assertTrue(cspHeader.contains("script-src"));
 			assertTrue(cspHeader.contains("'self'"));
 			assertTrue(cspHeader.contains("'strict-dynamic'"));
@@ -96,18 +60,13 @@ public class F103_ZK_5265MultiPolicyTest extends WebDriverTestCase {
 			assertTrue(cspHeader.contains("'nonce-"));
 
 			assertTrue(cspHeader.contains("style-src"));
-			assertTrue(cspHeader.contains("'self'"));
-			assertTrue(cspHeader.contains("'unsafe-inline'"));
-
 			assertTrue(cspHeader.contains("font-src"));
-			assertTrue(cspHeader.contains("'self'"));
-
 			assertTrue(cspHeader.contains("connect-src"));
-			assertTrue(cspHeader.contains("'self'"));
 
 			assertTrue(cspHeader.contains("frame-ancestors"));
 			assertTrue(cspHeader.contains("'none'"));
-		} catch (InterruptedException ignored) {
+		} finally {
+			conn.disconnect();
 		}
 	}
 

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/F103_ZK_5265PolicyDynamicTest.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/F103_ZK_5265PolicyDynamicTest.java
@@ -13,18 +13,12 @@ package org.zkoss.zktest.zats.test2;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.openqa.selenium.chrome.ChromeDriver;
-import org.openqa.selenium.devtools.DevTools;
-import org.openqa.selenium.devtools.v143.network.Network;
-import org.openqa.selenium.devtools.v143.network.model.Response;
 
 import org.zkoss.test.webdriver.ExternalZkXml;
 import org.zkoss.test.webdriver.ForkJVMTestOnly;
@@ -49,53 +43,20 @@ public class F103_ZK_5265PolicyDynamicTest extends WebDriverTestCase {
 	}
 
 	@Test
-	public void testHeader() {
-		connect();
-		DevTools devTools = ((ChromeDriver) driver).getDevTools();
-		devTools.createSession();
-
-		devTools.send(Network.enable(
-				Optional.empty(),
-				Optional.empty(),
-				Optional.empty(),
-				Optional.empty(),
-				Optional.empty()
-		));
-
-
-		AtomicReference<String> cspHeaderRef = new AtomicReference<>();
-		AtomicReference<String> cspReportOnlyRef = new AtomicReference<>();
-		CountDownLatch latch = new CountDownLatch(1);
-
-		devTools.addListener(Network.responseReceived(), response -> {
-			Response resp = response.getResponse();
-
-			if (resp.getUrl().contains(test_page)) {
-				Map<String, Object> headers = resp.getHeaders().toJson();
-				Object csp = headers.get("Content-Security-Policy");
-				Object cspReportOnly = headers.get("Content-Security-Policy-Report-Only");
-
-				cspHeaderRef.set(csp != null ? csp.toString() : null);
-				cspReportOnlyRef.set(cspReportOnly != null ? cspReportOnly.toString() : null);
-				latch.countDown();
-			}
-		});
-
-		driver.get(getAddress() + test_page);
-		waitResponse();
-
+	public void testHeader() throws IOException {
+		HttpURLConnection conn = (HttpURLConnection) new URL(getAddress() + test_page).openConnection();
+		conn.setRequestMethod("GET");
+		conn.connect();
 		try {
-			assertTrue(latch.await(10, TimeUnit.SECONDS));
-			assertNotNull(cspHeaderRef.get());
-			assertNull(cspReportOnlyRef.get());
-
-			String cspHeader = cspHeaderRef.get();
+			String cspHeader = conn.getHeaderField("Content-Security-Policy");
+			assertNotNull(cspHeader);
+			assertNull(conn.getHeaderField("Content-Security-Policy-Report-Only"));
 			assertTrue(cspHeader.contains("script-src"));
 			assertTrue(cspHeader.contains("'self'"));
 			assertTrue(cspHeader.contains("'unsafe-inline'"));
 			assertTrue(cspHeader.contains("'unsafe-eval'"));
-			driver.quit();
-		} catch (InterruptedException ignored) {
+		} finally {
+			conn.disconnect();
 		}
 	}
 

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/F103_ZK_5265PolicyTest.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/F103_ZK_5265PolicyTest.java
@@ -13,18 +13,12 @@ package org.zkoss.zktest.zats.test2;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.openqa.selenium.chrome.ChromeDriver;
-import org.openqa.selenium.devtools.DevTools;
-import org.openqa.selenium.devtools.v143.network.Network;
-import org.openqa.selenium.devtools.v143.network.model.Response;
 
 import org.zkoss.test.webdriver.ExternalZkXml;
 import org.zkoss.test.webdriver.ForkJVMTestOnly;
@@ -37,53 +31,21 @@ public class F103_ZK_5265PolicyTest extends WebDriverTestCase {
 	private static final String test_page = "/test2/F103-ZK-5265Policy.zul";
 
 	@Test
-	public void testHeader() {
-		connect();
-		DevTools devTools = ((ChromeDriver) driver).getDevTools();
-		devTools.createSession();
-
-		devTools.send(Network.enable(
-				Optional.empty(),
-				Optional.empty(),
-				Optional.empty(),
-				Optional.empty(),
-				Optional.empty()
-		));
-
-		AtomicReference<String> cspHeaderRef = new AtomicReference<>();
-		AtomicReference<String> cspReportOnlyRef = new AtomicReference<>();
-		CountDownLatch latch = new CountDownLatch(1);
-
-		devTools.addListener(Network.responseReceived(), response -> {
-			Response resp = response.getResponse();
-
-			if (resp.getUrl().endsWith(test_page)) {
-				Map<String, Object> headers = resp.getHeaders().toJson();
-				Object csp = headers.get("Content-Security-Policy");
-				Object cspReportOnly = headers.get("Content-Security-Policy-Report-Only");
-
-				cspHeaderRef.set(csp != null ? csp.toString() : null);
-				cspReportOnlyRef.set(cspReportOnly != null ? cspReportOnly.toString() : null);
-				latch.countDown();
-			}
-		});
-
-		driver.get(getAddress() + test_page);
-		waitResponse();
-
+	public void testHeader() throws IOException {
+		HttpURLConnection conn = (HttpURLConnection) new URL(getAddress() + test_page).openConnection();
+		conn.setRequestMethod("GET");
+		conn.connect();
 		try {
-			assertTrue(latch.await(10, TimeUnit.SECONDS));
-			assertNotNull(cspHeaderRef.get());
-			assertNull(cspReportOnlyRef.get());
-
-			String cspHeader = cspHeaderRef.get();
+			String cspHeader = conn.getHeaderField("Content-Security-Policy");
+			assertNotNull(cspHeader);
+			assertNull(conn.getHeaderField("Content-Security-Policy-Report-Only"));
 			assertTrue(cspHeader.contains("script-src"));
 			assertTrue(cspHeader.contains("'self'"));
 			assertTrue(cspHeader.contains("'unsafe-inline'"));
 			assertTrue(cspHeader.contains("'unsafe-eval'"));
 			assertTrue(cspHeader.contains("https://www.google-analytics.com"));
-			driver.quit();
-		} catch (InterruptedException ignored) {
+		} finally {
+			conn.disconnect();
 		}
 	}
 

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/F103_ZK_5265ReportTest.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/F103_ZK_5265ReportTest.java
@@ -13,18 +13,12 @@ package org.zkoss.zktest.zats.test2;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.openqa.selenium.chrome.ChromeDriver;
-import org.openqa.selenium.devtools.DevTools;
-import org.openqa.selenium.devtools.v143.network.Network;
-import org.openqa.selenium.devtools.v143.network.model.Response;
 
 import org.zkoss.test.webdriver.ExternalZkXml;
 import org.zkoss.test.webdriver.ForkJVMTestOnly;
@@ -49,54 +43,22 @@ public class F103_ZK_5265ReportTest extends WebDriverTestCase {
 	}
 
 	@Test
-	public void testHeader() {
-		connect();
-		DevTools devTools = ((ChromeDriver) driver).getDevTools();
-		devTools.createSession();
-
-		devTools.send(Network.enable(
-				Optional.empty(),
-				Optional.empty(),
-				Optional.empty(),
-				Optional.empty(),
-				Optional.empty()
-		));
-
-		AtomicReference<String> cspHeaderRef = new AtomicReference<>();
-		AtomicReference<String> cspReportOnlyRef = new AtomicReference<>();
-		CountDownLatch latch = new CountDownLatch(1);
-
-		devTools.addListener(Network.responseReceived(), response -> {
-			Response resp = response.getResponse();
-
-			if (resp.getUrl().endsWith(test_page)) {
-				Map<String, Object> headers = resp.getHeaders().toJson();
-				Object csp = headers.get("Content-Security-Policy");
-				Object cspReportOnly = headers.get("Content-Security-Policy-Report-Only");
-
-				cspHeaderRef.set(csp != null ? csp.toString() : null);
-				cspReportOnlyRef.set(cspReportOnly != null ? cspReportOnly.toString() : null);
-				latch.countDown();
-			}
-		});
-
-		driver.get(getAddress() + test_page);
-		waitResponse();
-
+	public void testHeader() throws IOException {
+		HttpURLConnection conn = (HttpURLConnection) new URL(getAddress() + test_page).openConnection();
+		conn.setRequestMethod("GET");
+		conn.connect();
 		try {
-			boolean completed = latch.await(5, TimeUnit.SECONDS);
-			assertTrue(completed);
-			assertNull(cspHeaderRef.get());
-			assertNotNull(cspReportOnlyRef.get());
-
-			String cspHeader = cspReportOnlyRef.get();
-			assertTrue(cspHeader.contains("script-src"));
-			assertTrue(cspHeader.contains("'self'"));
-			assertTrue(cspHeader.contains("'strict-dynamic'"));
-			assertTrue(cspHeader.contains("'unsafe-inline'"));
-			assertTrue(cspHeader.contains("'unsafe-eval'"));
-			assertTrue(cspHeader.contains("'nonce-"));
-		} catch (InterruptedException ignored) {
+			String cspReportOnly = conn.getHeaderField("Content-Security-Policy-Report-Only");
+			assertNull(conn.getHeaderField("Content-Security-Policy"));
+			assertNotNull(cspReportOnly);
+			assertTrue(cspReportOnly.contains("script-src"));
+			assertTrue(cspReportOnly.contains("'self'"));
+			assertTrue(cspReportOnly.contains("'strict-dynamic'"));
+			assertTrue(cspReportOnly.contains("'unsafe-inline'"));
+			assertTrue(cspReportOnly.contains("'unsafe-eval'"));
+			assertTrue(cspReportOnly.contains("'nonce-"));
+		} finally {
+			conn.disconnect();
 		}
 	}
 

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/F103_ZK_5265ReportUriTest.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/F103_ZK_5265ReportUriTest.java
@@ -13,18 +13,12 @@ package org.zkoss.zktest.zats.test2;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.openqa.selenium.chrome.ChromeDriver;
-import org.openqa.selenium.devtools.DevTools;
-import org.openqa.selenium.devtools.v143.network.Network;
-import org.openqa.selenium.devtools.v143.network.model.Response;
 
 import org.zkoss.test.webdriver.ExternalZkXml;
 import org.zkoss.test.webdriver.ForkJVMTestOnly;
@@ -49,49 +43,18 @@ public class F103_ZK_5265ReportUriTest extends WebDriverTestCase {
 	}
 
 	@Test
-	public void testHeader(){
-		connect();
-		DevTools devTools = ((ChromeDriver) driver).getDevTools();
-		devTools.createSession();
-
-		devTools.send(Network.enable(
-				Optional.empty(),
-				Optional.empty(),
-				Optional.empty(),
-				Optional.empty(),
-				Optional.empty()
-		));
-
-		AtomicReference<String> cspHeaderRef = new AtomicReference<>();
-		AtomicReference<String> cspReportOnlyRef = new AtomicReference<>();
-		CountDownLatch latch = new CountDownLatch(1);
-
-		devTools.addListener(Network.responseReceived(), response -> {
-			Response resp = response.getResponse();
-
-			if (resp.getUrl().endsWith(test_page)) {
-				Map<String, Object> headers = resp.getHeaders().toJson();
-				Object csp = headers.get("Content-Security-Policy");
-				Object cspReportOnly = headers.get("Content-Security-Policy-Report-Only");
-
-				cspHeaderRef.set(csp != null ? csp.toString() : null);
-				cspReportOnlyRef.set(cspReportOnly != null ? cspReportOnly.toString() : null);
-				latch.countDown();
-			}
-		});
-
-		driver.get(getAddress() + test_page);
-		waitResponse();
-
+	public void testHeader() throws IOException {
+		HttpURLConnection conn = (HttpURLConnection) new URL(getAddress() + test_page).openConnection();
+		conn.setRequestMethod("GET");
+		conn.connect();
 		try {
-			assertTrue(latch.await(10, TimeUnit.SECONDS));
-			assertNull(cspHeaderRef.get());
-			assertNotNull(cspReportOnlyRef.get());
-			assertTrue(cspReportOnlyRef.toString().contains(endpoint));
-
-			String cspHeader = cspReportOnlyRef.get();
-			assertTrue(cspHeader.contains("report-uri"));
-		} catch (InterruptedException ignored) {
+			String cspReportOnly = conn.getHeaderField("Content-Security-Policy-Report-Only");
+			assertNull(conn.getHeaderField("Content-Security-Policy"));
+			assertNotNull(cspReportOnly);
+			assertTrue(cspReportOnly.contains(endpoint));
+			assertTrue(cspReportOnly.contains("report-uri"));
+		} finally {
+			conn.disconnect();
 		}
 	}
 }


### PR DESCRIPTION
CSP-header tests (`F103_ZK_5265*` and `B103_ZK_6055`) and request-header network-throttling tests (`F102_ZK_5461`, `B96_ZK_4194`) used CDP namespaces pinned to a specific Chrome major (v142/v143) via `selenium-devtools-vNN:4.39.0`. Once CI Chrome drifted >=5 majors past the pinned version Selenium fell back to a NoOp CDP implementation, and any DevTools call threw DevToolsException.

Replaced with version-free APIs already shipped in selenium-java 4.39.0:
- Response-header inspection (CSP) -> java.net.HttpURLConnection
- Request-header observation (F102) -> Selenium BiDi (W3C standard)
- Network throttling (B96) -> ChromiumDriver.setNetworkConditions (chromedriver vendor endpoint, not CDP)

selenium-devtools-v143 dependency removed from zktest/build.gradle. F102 enables BiDi via webSocketUrl capability override.