### PR TITLE
[WIP] Fix Chrome accept-lang parameter

### DIFF
--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B102_ZK_5615_DE_Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B102_ZK_5615_DE_Test.java
@@ -32,7 +32,7 @@ public class B102_ZK_5615_DE_Test extends WebDriverTestCase {
     @Override
     protected ChromeOptions getWebDriverOptions() {
         return super.getWebDriverOptions()
-                .addArguments("--lang=" + locale)
+                .addArguments("--lang=" + locale, "--accept-lang=" + locale)
                 .setExperimentalOption("prefs", Map.of(
                         "intl.accept_languages", locale
                 ));

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B102_ZK_5615_ES_Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B102_ZK_5615_ES_Test.java
@@ -32,7 +32,7 @@ public class B102_ZK_5615_ES_Test extends WebDriverTestCase {
     @Override
     protected ChromeOptions getWebDriverOptions() {
         return super.getWebDriverOptions()
-                .addArguments("--lang=" + locale)
+                .addArguments("--lang=" + locale, "--accept-lang=" + locale)
                 .setExperimentalOption("prefs", Map.of(
                         "intl.accept_languages", locale
                 ));

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B102_ZK_5615_FR_Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B102_ZK_5615_FR_Test.java
@@ -32,7 +32,7 @@ public class B102_ZK_5615_FR_Test extends WebDriverTestCase {
     @Override
     protected ChromeOptions getWebDriverOptions() {
         return super.getWebDriverOptions()
-                .addArguments("--lang=" + locale)
+                .addArguments("--lang=" + locale, "--accept-lang=" + locale)
                 .setExperimentalOption("prefs", Map.of(
                         "intl.accept_languages", locale
                 ));

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B102_ZK_5615_JP_Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B102_ZK_5615_JP_Test.java
@@ -32,7 +32,7 @@ public class B102_ZK_5615_JP_Test extends WebDriverTestCase {
     @Override
     protected ChromeOptions getWebDriverOptions() {
         return super.getWebDriverOptions()
-                .addArguments("--lang=" + locale)
+                .addArguments("--lang=" + locale, "--accept-lang=" + locale)
                 .setExperimentalOption("prefs", Map.of(
                         "intl.accept_languages", locale
                 ));

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B102_ZK_5615_US_Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B102_ZK_5615_US_Test.java
@@ -32,7 +32,7 @@ public class B102_ZK_5615_US_Test extends WebDriverTestCase {
     @Override
     protected ChromeOptions getWebDriverOptions() {
         return super.getWebDriverOptions()
-                .addArguments("--lang=" + locale)
+                .addArguments("--lang=" + locale, "--accept-lang=" + locale)
                 .setExperimentalOption("prefs", Map.of(
                         "intl.accept_languages", locale
                 ));

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B102_ZK_5615_Zh_Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B102_ZK_5615_Zh_Test.java
@@ -32,7 +32,7 @@ public class B102_ZK_5615_Zh_Test extends WebDriverTestCase {
     @Override
     protected ChromeOptions getWebDriverOptions() {
         return super.getWebDriverOptions()
-                .addArguments("--lang=" + locale)
+                .addArguments("--lang=" + locale, "--accept-lang=" + locale)
                 .setExperimentalOption("prefs", Map.of(
                         "intl.accept_languages", locale
                 ));

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B102_ZK_5688Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B102_ZK_5688Test.java
@@ -33,7 +33,7 @@ public class B102_ZK_5688Test extends WebDriverTestCase {
     @Override
     protected ChromeOptions getWebDriverOptions() {
         return super.getWebDriverOptions()
-                .addArguments("--lang=de-DE")
+                .addArguments("--lang=de-DE", "--accept-lang=de-DE")
                 .setExperimentalOption("prefs", Map.of(
                         "intl.accept_languages", "de-DE"
                 ));

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B36_2939911Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B36_2939911Test.java
@@ -29,7 +29,7 @@ public class B36_2939911Test extends DockerWebDriverTestCase {
 	@Override
 	protected ChromeOptions getWebDriverOptions() {
 		return super.getWebDriverOptions()
-				.addArguments("--lang=th-TH")
+				.addArguments("--lang=th-TH", "--accept-lang=th-TH")
 				.setExperimentalOption("prefs", Collections.singletonMap("intl.accept_languages", "th-TH"));
 	}
 

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B36_2940739Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B36_2940739Test.java
@@ -28,7 +28,7 @@ public class B36_2940739Test extends DockerWebDriverTestCase {
 	@Override
 	protected ChromeOptions getWebDriverOptions() {
 		return super.getWebDriverOptions()
-				.addArguments("--lang=th-TH")
+				.addArguments("--lang=th-TH", "--accept-lang=th-TH")
 				.setExperimentalOption("prefs", Collections.singletonMap("intl.accept_languages", "th-TH"));
 	}
 

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B36_3002536Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B36_3002536Test.java
@@ -26,7 +26,7 @@ public class B36_3002536Test extends DockerWebDriverTestCase {
 	@Override
 	protected ChromeOptions getWebDriverOptions() {
 		return super.getWebDriverOptions()
-				.addArguments("--lang=fr-FR")
+				.addArguments("--lang=fr-FR", "--accept-lang=fr-FR")
 				.setExperimentalOption("prefs", Collections.singletonMap("intl.accept_languages", "fr-FR"));
 	}
 

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B50_2934252Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B50_2934252Test.java
@@ -29,7 +29,7 @@ public class B50_2934252Test extends DockerWebDriverTestCase {
 	@Override
 	protected ChromeOptions getWebDriverOptions() {
 		return super.getWebDriverOptions()
-				.addArguments("--lang=th-TH")
+				.addArguments("--lang=th-TH", "--accept-lang=th-TH")
 				.setExperimentalOption("prefs", Collections.singletonMap("intl.accept_languages", "th-TH"));
 	}
 

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B50_3003756Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B50_3003756Test.java
@@ -29,7 +29,7 @@ public class B50_3003756Test extends DockerWebDriverTestCase {
 	protected ChromeOptions getWebDriverOptions() {
 		String lang = acceptLang.get();
 		return super.getWebDriverOptions()
-				.addArguments("--lang=" + lang)
+				.addArguments("--lang=" + lang, "--accept-lang=" + lang)
 				.setExperimentalOption("prefs", Collections.singletonMap("intl.accept_languages", lang));
 	}
 

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B50_3052381Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B50_3052381Test.java
@@ -35,7 +35,7 @@ public class B50_3052381Test extends DockerWebDriverTestCase {
 	@Override
 	protected ChromeOptions getWebDriverOptions() {
 		return super.getWebDriverOptions()
-				.addArguments("--lang=it-IT")
+				.addArguments("--lang=it-IT", "--accept-lang=it-IT")
 				.setExperimentalOption("prefs", Collections.singletonMap("intl.accept_languages", "it-IT"));
 	}
 

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B70_ZK_2477Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B70_ZK_2477Test.java
@@ -33,7 +33,7 @@ public class B70_ZK_2477Test extends DockerWebDriverTestCase {
 	@Override
 	protected ChromeOptions getWebDriverOptions() {
 		return super.getWebDriverOptions()
-				.addArguments("--lang=ro-RO") // Romanian (Romania)
+				.addArguments("--lang=ro-RO", "--accept-lang=ro-RO") // Romanian (Romania)
 				.setExperimentalOption("prefs", Collections.singletonMap("intl.accept_languages", "ro-RO"));
 	}
 

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B85_ZK_3821Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B85_ZK_3821Test.java
@@ -32,7 +32,7 @@ public class B85_ZK_3821Test extends DockerWebDriverTestCase {
 	@Override
 	protected ChromeOptions getWebDriverOptions() {
 		return super.getWebDriverOptions()
-				.addArguments("--lang=de-DE")
+				.addArguments("--lang=de-DE", "--accept-lang=de-DE")
 				.setExperimentalOption("prefs", Collections.singletonMap("intl.accept_languages", "de-DE"));
 	}
 

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B96_ZK_4780Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B96_ZK_4780Test.java
@@ -33,7 +33,7 @@ public class B96_ZK_4780Test extends DockerWebDriverTestCase {
 	@Override
 	protected ChromeOptions getWebDriverOptions() {
 		return super.getWebDriverOptions()
-				.addArguments("--lang=de-DE")
+				.addArguments("--lang=de-DE", "--accept-lang=de-DE")
 				.setExperimentalOption("prefs", Collections.singletonMap("intl.accept_languages", "de-DE"))
 				.setExperimentalOption("mobileEmulation", Collections.singletonMap("deviceName", "iPad"));
 	}


### PR DESCRIPTION
testGerman/testEnglish assert that the doublebox renders a locale-aware "35,00" / "35.00", which requires Chrome to send the right Accept-Language header to the server.

The previous setup (added in 92adac912e when this test was moved to DockerWebDriverTestCase) relies on:
  - --lang=<lang>                       (Chrome CLI arg)
  - prefs.intl.accept_languages=<lang>  (user pref via chromedriver)

Both have become unreliable as selenium/node-chrome:latest drifted to newer Chrome / chromedriver. In current Chrome, --lang controls the UI language only; the chromium switch that actually populates the Accept-Language HTTP header is --accept-lang. The user pref path is also not guaranteed in Selenium Grid mode -- chromedriver does not always write the profile prefs before Chrome issues the first request, so intl.accept_languages can be ignored on the initial GET. When both paths fail, Chrome falls back to the container locale (en_US), so doublebox formats with "." and the German assertion fails.

Pass --accept-lang=<lang> alongside the existing flags. It is read at process start, independent of profile-prefs handling, so it survives both the Chrome behaviour change and any chromedriver pref-writing regressions while keeping the old flags as a fallback for older images.