### PR TITLE
ZK-6095: Support ctrlKeys in borderlayout

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -10,6 +10,7 @@ ZK 11.0.0
   ZK-6099: Add skeleton attribute on existing components to PE
   ZK-6086: code editor
   ZK-5997: Support Content Security Policy Without 'unsafe-inline'
+  ZK-6095: Support ctrlKeys in borderlayout
 
 * Bugs
   ZK-5670: org.zkoss.zul.progressbox.position doesn't take effect in an embedded zul
@@ -44,6 +45,7 @@ ZK 11.0.0
 
 * Upgrade Notes
   + URLs.sanitizeURL now returns non-http/https URLs unchanged. Applications that call this public API directly should not rely on it to validate or reject container-owned resource URL formats such as jar/wsjar URLs without an entry separator.
+  + Borderlayout is extended from XulElement since ZK 11.0.0, so it also accepts the context, popup and tooltip attributes.
   + Upgrade httpcore5 to 5.4.3 to fix vulnerabilities
   + Upgrade jackson-databind to 2.22.1 to fix vulnerabilities
   + Upgrade tomcat-jasper-el to 9.0.120 to fix vulnerabilities

--- a/zktest/src/main/java/org/zkoss/zktest/test2/F110_ZK_6095_BorderlayoutVM.java
+++ b/zktest/src/main/java/org/zkoss/zktest/test2/F110_ZK_6095_BorderlayoutVM.java
@@ -1,0 +1,31 @@
+/* F110_ZK_6095_BorderlayoutVM.java
+
+		Purpose:
+
+		Description:
+
+		History:
+				Tue May 26 17:00:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.test2;
+
+import org.zkoss.bind.annotation.BindingParam;
+import org.zkoss.bind.annotation.Command;
+import org.zkoss.bind.annotation.NotifyChange;
+
+public class F110_ZK_6095_BorderlayoutVM {
+
+	private String shortcutKeys = "^k";
+	private String result = "none";
+
+	public String getShortcutKeys() { return shortcutKeys; }
+	public String getResult() { return result; }
+
+	@Command
+	@NotifyChange("result")
+	public void onShortcut(@BindingParam("code") int code) {
+		result = "ctrlKey:" + code;
+	}
+}

--- a/zktest/src/main/webapp/test2/F110-ZK-6095-mvvm.zul
+++ b/zktest/src/main/webapp/test2/F110-ZK-6095-mvvm.zul
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+F110-ZK-6095-mvvm.zul
+
+		Purpose:
+
+		Description:
+
+		History:
+				Tue May 26 17:00:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+-->
+<zk xmlns="http://www.zkoss.org/2005/zul">
+	<window apply="org.zkoss.bind.BindComposer"
+			viewModel="@id('vm') @init('org.zkoss.zktest.test2.F110_ZK_6095_BorderlayoutVM')">
+		<label multiline="true">
+			ctrlKeys is bound via @load(vm.shortcutKeys) and onCtrlKey via @command.
+			Focus the textbox and press Ctrl+K — the VM should record the keyCode.
+		</label>
+		<borderlayout id="bl" height="200px"
+				ctrlKeys="@load(vm.shortcutKeys)"
+				onCtrlKey="@command('onShortcut', code=event.keyCode)">
+			<center>
+				<textbox id="tb" placeholder="focus me, then press Ctrl+K" width="320px"/>
+			</center>
+		</borderlayout>
+		boundCtrlKeys: <label id="boundCtrlKeys" value="@load(vm.shortcutKeys)"/>
+		<separator/>
+		result: <label id="result" value="@load(vm.result)"/>
+	</window>
+</zk>

--- a/zktest/src/main/webapp/test2/F110-ZK-6095-override.zul
+++ b/zktest/src/main/webapp/test2/F110-ZK-6095-override.zul
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+F110-ZK-6095-override.zul
+
+		Purpose:
+
+		Description:
+
+		History:
+				Tue May 26 17:00:00 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+	<label multiline="true">
+		Both the borderlayout and its center region declare ctrlKeys="^k".
+		Focus the textbox inside center and press Ctrl+K — the closer-to-focus
+		(center) handler should fire and the borderlayout's should NOT.
+	</label>
+	<borderlayout id="bl" height="200px" ctrlKeys="^k"
+			onCtrlKey='result.setValue("bl");'>
+		<center ctrlKeys="^k" onCtrlKey='result.setValue("region");'>
+			<textbox id="tb" placeholder="focus me, then press Ctrl+K" width="320px"/>
+		</center>
+	</borderlayout>
+	result:
+	<label id="result" />
+</zk>

--- a/zktest/src/main/webapp/test2/F110-ZK-6095.zul
+++ b/zktest/src/main/webapp/test2/F110-ZK-6095.zul
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+F110-ZK-6095.zul
+
+		Purpose:
+
+		Description:
+
+		History:
+				Wed May 13 17:10:17 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+	<label multiline="true">
+		1. Click on a textbox inside any region to give it focus.
+		2. Press Ctrl+K — the result label should show "ctrlKey:75" (75 is the keyCode of K).
+		3. Press Ctrl+H — the result label should show "ctrlKey:72".
+		4. Press Ctrl+J — the result should stay unchanged (J is not in ctrlKeys).
+		5. Click "Test empty" — the empty-result label should show "true" (empty string → null).
+		The borderlayout itself is the ctrlKeys handler — no per-region ctrlKeys is declared,
+		yet pressing the shortcut inside any region routes onCtrlKey to the borderlayout.
+	</label>
+	<borderlayout id="bl" height="200px" ctrlKeys="^k^h"
+			onCtrlKey='result.setValue("ctrlKey:" + event.getKeyCode());'>
+		<north size="40px">
+			<textbox id="tbNorth" placeholder="north — focus me, then press Ctrl+K" width="320px"/>
+		</north>
+		<center>
+			<textbox id="tb" placeholder="center — focus me, then press Ctrl+K or Ctrl+H" width="320px"/>
+		</center>
+		<south size="40px">south</south>
+	</borderlayout>
+	result:
+	<label id="result" />
+	<separator/>
+	<button id="testEmpty" label="Test empty"
+			onClick='bl.setCtrlKeys(""); emptyResult.setValue(String.valueOf(bl.getCtrlKeys() == null));'/>
+	emptyResult:
+	<label id="emptyResult" />
+</zk>

--- a/zktest/src/main/webapp/test2/config.properties
+++ b/zktest/src/main/webapp/test2/config.properties
@@ -4103,6 +4103,9 @@ F86-ZK-4235.zul=A,E,datefmt,library-property
 ##zats##F110-ZK-6123.zul=A,H,Daterangebox
 ##zats##F110-ZK-6086-Codeeditor.zul=A,E,Codeeditor
 ##zats##F110-ZK-6086-Codeeditor-csp.zul=A,E,Codeeditor,CSP
+##zats##F110-ZK-6095.zul=A,E,Borderlayout,ctrlKeys,onCtrlKey
+##zats##F110-ZK-6095-override.zul=A,E,Borderlayout,ctrlKeys,onCtrlKey
+##zats##F110-ZK-6095-mvvm.zul=A,E,Borderlayout,ctrlKeys,onCtrlKey,MVVM
 
 # Complex Test Case
 #

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/F110_ZK_6095Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/F110_ZK_6095Test.java
@@ -1,0 +1,85 @@
+/* F110_ZK_6095Test.java
+
+		Purpose:
+
+		Description:
+
+		History:
+				Wed May 13 17:10:17 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.interactions.Actions;
+
+import org.zkoss.test.webdriver.WebDriverTestCase;
+import org.zkoss.test.webdriver.ztl.JQuery;
+
+public class F110_ZK_6095Test extends WebDriverTestCase {
+
+	private void pressCtrl(String key) {
+		Actions action = getActions();
+		action.keyDown(Keys.CONTROL).sendKeys(key).keyUp(Keys.CONTROL).perform();
+		waitResponse();
+	}
+
+	@Test
+	public void test() {
+		connect();
+		// focus the textbox inside the center region so keydown originates
+		// inside the borderlayout's widget subtree
+		focus(jq("$tb"));
+		waitResponse();
+
+		JQuery result = jq("$result");
+		pressCtrl("k");
+		assertEquals("ctrlKey:75", result.text());
+
+		pressCtrl("h");
+		assertEquals("ctrlKey:72", result.text());
+
+		// negative chord: J is not in ctrlKeys, result must not change
+		pressCtrl("j");
+		assertEquals("ctrlKey:72", result.text());
+
+		// focus inside north region — chord must still route to the borderlayout
+		focus(jq("$tbNorth"));
+		waitResponse();
+		pressCtrl("k");
+		assertEquals("ctrlKey:75", result.text());
+
+		// empty string is normalized to null on the server
+		click(jq("$testEmpty"));
+		waitResponse();
+		assertEquals("true", jq("$emptyResult").text());
+	}
+
+	@Test
+	public void testPerRegionOverride() {
+		connect("/test2/F110-ZK-6095-override.zul");
+		focus(jq("$tb"));
+		waitResponse();
+
+		pressCtrl("k");
+		// the region's handler is closer to focus; the event must not bubble
+		// up to the borderlayout
+		assertEquals("region", jq("$result").text());
+	}
+
+	@Test
+	public void testMVVMBinding() {
+		connect("/test2/F110-ZK-6095-mvvm.zul");
+		// ctrlKeys was @load-bound from the view-model
+		assertEquals("^k", jq("$boundCtrlKeys").text());
+
+		focus(jq("$tb"));
+		waitResponse();
+		pressCtrl("k");
+		assertEquals("ctrlKey:75", jq("$result").text());
+	}
+}

--- a/zul/src/main/java/org/zkoss/zul/Borderlayout.java
+++ b/zul/src/main/java/org/zkoss/zul/Borderlayout.java
@@ -23,8 +23,8 @@ import org.slf4j.LoggerFactory;
 
 import org.zkoss.lang.Library;
 import org.zkoss.zk.ui.Component;
-import org.zkoss.zk.ui.HtmlBasedComponent;
 import org.zkoss.zk.ui.UiException;
+import org.zkoss.zul.impl.XulElement;
 
 /**
  * A border layout is a layout container for arranging and resizing
@@ -76,7 +76,7 @@ import org.zkoss.zk.ui.UiException;
  * @author jumperchen
  * @since 5.0.0
  */
-public class Borderlayout extends HtmlBasedComponent {
+public class Borderlayout extends XulElement {
 	private static final Logger log = LoggerFactory.getLogger(Borderlayout.class);
 
 	/**

--- a/zul/src/main/resources/metainfo/xml/zul.xsd
+++ b/zul/src/main/resources/metainfo/xml/zul.xsd
@@ -1253,7 +1253,7 @@
 			<xs:element ref="west" minOccurs="0" maxOccurs="1" />
 			<xs:element ref="east" minOccurs="0" maxOccurs="1" />
 		</xs:all>
-		<xs:attributeGroup ref="htmlBasedComponentAttrGroup" />
+		<xs:attributeGroup ref="xulElementAttrGroup" />
 		<xs:attributeGroup ref="rootAttrGroup" />
 		<xs:attribute name="animationDisabled" type="booleanType" use="optional" />
 	</xs:complexType>


### PR DESCRIPTION
Please merge this alongside https://github.com/zkoss/zkcml/pull/1380.