### PR TITLE
ZK-6102: SimpleDesktopCache _cleanup timers are not removed, cause Tomcat errors on application stop

### DIFF
--- a/zk/src/main/java/org/zkoss/zk/ui/impl/SessionDesktopCacheProvider.java
+++ b/zk/src/main/java/org/zkoss/zk/ui/impl/SessionDesktopCacheProvider.java
@@ -16,6 +16,10 @@ Copyright (C) 2006 Potix Corporation. All Rights Reserved.
 */
 package org.zkoss.zk.ui.impl;
 
+import java.util.Collections;
+import java.util.Set;
+import java.util.WeakHashMap;
+
 import org.zkoss.zk.ui.Session;
 import org.zkoss.zk.ui.WebApp;
 import org.zkoss.zk.ui.sys.DesktopCache;
@@ -35,21 +39,43 @@ import org.zkoss.zk.ui.sys.SessionCtrl;
  */
 public class SessionDesktopCacheProvider implements DesktopCacheProvider {
 	private WebApp _wapp;
+	/** Live per-session caches, tracked so {@link #stop} can cancel their cleaner
+	 * timers (ZK-5435) without destroying passivatable desktops. Weak keys: an
+	 * armed cache is held reachable by its own running timer, so an abandoned one
+	 * drops out by itself once its timer is cancelled. Every access — and
+	 * {@link #_stopped} — is guarded by this set's monitor. */
+	private final Set<SimpleDesktopCache> _caches = Collections
+			.newSetFromMap(new WeakHashMap<SimpleDesktopCache, Boolean>());
+	/** Latched by {@link #stop} so a late activation cannot re-arm a cancelled timer. */
+	private boolean _stopped;
 
 	//-- DesktopCacheProvider --//
 	public DesktopCache getDesktopCache(Session sess) {
 		final SessionCtrl sessCtrl = (SessionCtrl) sess;
 		DesktopCache dc = sessCtrl.getDesktopCache();
-		if (dc == null) {
-			synchronized (this) {
-				dc = sessCtrl.getDesktopCache();
-				if (dc == null) {
-					dc = new SimpleDesktopCache(_wapp.getConfiguration());
-					sessCtrl.setDesktopCache(dc);
-				}
+		if (dc != null)
+			return dc;
+		synchronized (this) {
+			dc = sessCtrl.getDesktopCache();
+			if (dc == null) {
+				dc = new SimpleDesktopCache(_wapp.getConfiguration());
+				sessCtrl.setDesktopCache(dc);
 			}
 		}
+		registerCleaner(dc); // track on creation only, not per request
 		return dc;
+	}
+
+	private void registerCleaner(DesktopCache dc) {
+		if (dc instanceof SimpleDesktopCache) {
+			final SimpleDesktopCache sdc = (SimpleDesktopCache) dc;
+			synchronized (_caches) {
+				if (_stopped)
+					sdc.shutdownCleaner();
+				else
+					_caches.add(sdc);
+			}
+		}
 	}
 
 	public void sessionDestroyed(Session sess) {
@@ -57,6 +83,11 @@ public class SessionDesktopCacheProvider implements DesktopCacheProvider {
 		final DesktopCache dc = sessCtrl.getDesktopCache();
 		if (dc != null) {
 			sessCtrl.setDesktopCache(null);
+			if (dc instanceof SimpleDesktopCache) {
+				synchronized (_caches) {
+					_caches.remove(dc);
+				}
+			}
 			dc.stop();
 		}
 	}
@@ -73,15 +104,29 @@ public class SessionDesktopCacheProvider implements DesktopCacheProvider {
 	 */
 	public void sessionDidActivate(Session sess) {
 		final DesktopCache dc = ((SessionCtrl) sess).getDesktopCache();
-		if (dc != null)
-			dc.sessionDidActivate(sess);
+		if (dc != null) {
+			dc.sessionDidActivate(sess); // re-arms the transient cleaner timer
+			registerCleaner(dc); // track the reactivated cache (or cancel if stopped)
+		}
 	}
 
 	public void start(WebApp wapp) {
+		synchronized (_caches) {
+			_stopped = false;
+		}
 		_wapp = wapp;
 	}
 
 	public void stop(WebApp wapp) {
+		// cancel the cleaner timers without destroying (possibly passivating) desktops
+		final SimpleDesktopCache[] caches;
+		synchronized (_caches) {
+			_stopped = true;
+			caches = _caches.toArray(new SimpleDesktopCache[0]);
+			_caches.clear();
+		}
+		for (SimpleDesktopCache dc : caches)
+			dc.shutdownCleaner();
 		_wapp = null;
 	}
 }

--- a/zk/src/main/java/org/zkoss/zk/ui/impl/SimpleDesktopCache.java
+++ b/zk/src/main/java/org/zkoss/zk/ui/impl/SimpleDesktopCache.java
@@ -59,15 +59,37 @@ public class SimpleDesktopCache implements DesktopCache, java.io.Serializable {
 	//it is possible if we re-boot the server
 
 	private transient Timer _cleaner;
+	/** Latched by {@link #shutdownCleaner} so a late activation cannot re-arm the timer. */
+	private transient boolean _cleanerStopped;
 	public SimpleDesktopCache(Configuration config) {
 		_desktops = new Cache(config);
 
 		// ZK-5435
 		int desktopMaxInactiveInterval = config.getDesktopMaxInactiveInterval();
-		if (desktopMaxInactiveInterval >= 0) {
-			_cleaner = new Timer();
-			_cleaner.scheduleAtFixedRate(new CleanerTask(), desktopMaxInactiveInterval * 1_000L, desktopMaxInactiveInterval * 1_000L);
+		if (desktopMaxInactiveInterval >= 0)
+			startCleaner(desktopMaxInactiveInterval * 1_000L);
+	}
+
+	private synchronized void startCleaner(long period) {
+		if (_cleanerStopped)
+			return;
+		stopCleaner();
+		_cleaner = new Timer();
+		_cleaner.scheduleAtFixedRate(new CleanerTask(), period, period);
+	}
+
+	/** Cancels the desktop cleaner timer, if any. */
+	/*package*/ synchronized void stopCleaner() {
+		if (_cleaner != null) {
+			_cleaner.cancel();
+			_cleaner = null;
 		}
+	}
+
+	/** Cancels the cleaner timer and blocks re-arming; called on web-app stop. */
+	/*package*/ synchronized void shutdownCleaner() {
+		_cleanerStopped = true;
+		stopCleaner();
 	}
 
 	//-- DesktopCache --//
@@ -191,6 +213,7 @@ public class SimpleDesktopCache implements DesktopCache, java.io.Serializable {
 		} finally {
 			_desktops.disableExpunge(old);
 		}
+		stopCleaner(); // transient timer; sessionDidActivate re-arms after restore
 	}
 
 	/** Invokes {@link DesktopCtrl#sessionDidActivate} for each
@@ -209,11 +232,8 @@ public class SimpleDesktopCache implements DesktopCache, java.io.Serializable {
 				((DesktopCtrl) desktop).sessionDidActivate(sess);
 
 			int lifetime = _desktops.getLifetime();
-			if (lifetime >= 0 && lifetime < Integer.MAX_VALUE / 4) {
-				// enable cleaner timer
-				_cleaner = new Timer();
-				_cleaner.scheduleAtFixedRate(new CleanerTask(), lifetime, lifetime);
-			}
+			if (lifetime >= 0 && lifetime < Integer.MAX_VALUE / 4)
+				startCleaner(lifetime);
 		} finally {
 			_desktops.disableExpunge(old);
 		}
@@ -222,23 +242,22 @@ public class SimpleDesktopCache implements DesktopCache, java.io.Serializable {
 	public void stop() {
 		if (log.isDebugEnabled())
 			log.debug("Invalidated and remove: {}", _desktops);
-		final boolean old = _desktops.disableExpunge(true);
 		try {
-			ArrayList<Desktop> desktops = null;
-			synchronized (_desktops) {
-				desktops = new ArrayList<Desktop>(_desktops.values());
-				_desktops.clear();
-			}
-			for (Desktop desktop : desktops) {
-				desktopDestroyed(desktop);
+			final boolean old = _desktops.disableExpunge(true);
+			try {
+				ArrayList<Desktop> desktops = null;
+				synchronized (_desktops) {
+					desktops = new ArrayList<Desktop>(_desktops.values());
+					_desktops.clear();
+				}
+				for (Desktop desktop : desktops) {
+					desktopDestroyed(desktop);
+				}
+			} finally {
+				_desktops.disableExpunge(old);
 			}
 		} finally {
-			_desktops.disableExpunge(old);
-		}
-
-		// ZK-5435
-		if (_cleaner != null) {
-			_cleaner.cancel();
+			stopCleaner();
 		}
 	}
 

--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -25,6 +25,7 @@ ZK 10.4.0
   ZK-6079: zul.xsd : toolbar only allows one child component instead of multiple
   ZK-6075: URL exception in IBM WebSphere / Open Liberty
   ZK-6011: an invalid post request still gets the http response 200
+  ZK-6102: SimpleDesktopCache _cleanup timers are not removed, cause Tomcat errors on application stop
 
 * Upgrade Notes
   + URLs.sanitizeURL now returns non-http/https URLs unchanged. Applications that call this public API directly should not rely on it to validate or reject container-owned resource URL formats such as jar/wsjar URLs without an entry separator.

--- a/zktest/src/main/webapp/test2/B104-ZK-6102.zul
+++ b/zktest/src/main/webapp/test2/B104-ZK-6102.zul
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+B104-ZK-6102.zul
+
+		Purpose:
+
+		Description:
+
+		History:
+				Tue Jun 23 10:58:43 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+	<label multiline="true">
+		0. Deploy this app to Tomcat (start by command line) with
+		   desktop-config/desktop-timeout set to a positive value in zk.xml
+		   so SimpleDesktopCache starts its cleaner timer, e.g.
+		   &lt;desktop-config>&lt;desktop-timeout>3600&lt;/desktop-timeout>&lt;/desktop-config>
+		1. Open this page in several browser sessions (use incognito windows
+		   to get more than one session concurrently).
+		2. Stop / undeploy the app (Tomcat manager or command line).
+		3. You should NOT see any warning like:
+		   "The web application [app] appears to have started a thread named
+		   [Timer-N] but has failed to stop it. This is very likely to create
+		   a memory leak."
+	</label>
+	<div>
+		<label value="ZK-6102 desktop cache cleaner timer leak"/>
+	</div>
+</zk>

--- a/zktest/src/main/webapp/test2/config.properties
+++ b/zktest/src/main/webapp/test2/config.properties
@@ -3288,6 +3288,7 @@ B90-ZK-4431.zul=A,E,Multislider
 ##zats##B104-ZK-6079.zul=A,E,Toolbar,Toolbarbutton,zul.xsd
 ##zats##B104-ZK-6075.zul=A,E,URL,WebSphere,Liberty,wsjar
 ##zats##B104-ZK-6011.zul=A,M,DHtmlUpdateServlet,AU,security
+##zats##B104-ZK-6102.zul=A,E,SimpleDesktopCache,DesktopCacheProvider,Timer,thread,WebAppCleanup
 
 ##
 # Features - 3.0.x version

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B104_ZK_6102Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B104_ZK_6102Test.java
@@ -1,0 +1,278 @@
+/* B104_ZK_6102Test.java
+
+	Purpose:
+
+	Description:
+
+	History:
+		Tue Jun 23 10:58:43 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import org.zkoss.zk.ui.Desktop;
+import org.zkoss.zk.ui.Session;
+import org.zkoss.zk.ui.WebApp;
+import org.zkoss.zk.ui.impl.SessionDesktopCacheProvider;
+import org.zkoss.zk.ui.impl.SimpleDesktopCache;
+import org.zkoss.zk.ui.sys.DesktopCache;
+import org.zkoss.zk.ui.sys.DesktopCtrl;
+import org.zkoss.zk.ui.sys.SessionCtrl;
+import org.zkoss.zk.ui.util.Configuration;
+
+/**
+ * ZK-6102: SimpleDesktopCache cleaner timers must not survive web app stop.
+ */
+public class B104_ZK_6102Test {
+
+	@Test
+	public void appStopShouldCancelCleanerTimersWithoutDestroyingDesktops() throws Exception {
+		final SessionDesktopCacheProvider provider = new SessionDesktopCacheProvider();
+		final WebApp wapp = stubWebApp(newConfiguration());
+		provider.start(wapp);
+		try {
+			final Set<Thread> before = timerThreads();
+			final SimpleDesktopCache cache = (SimpleDesktopCache) provider.getDesktopCache(stubSession(wapp));
+			final Desktop desktop = newDesktop("zk6102-live");
+			cache.addDesktop(desktop);
+			final Set<Thread> created = createdTimerThreads(before);
+			assertEquals(1, created.size(), "the session-scoped desktop cache should start one cleaner timer");
+
+			provider.stop(wapp);
+
+			assertAllDead(created, "cleaner timer leaked after webapp stop");
+			assertSame(desktop, cache.getDesktopIfAny("zk6102-live"),
+					"webapp stop must not destroy passivatable session desktops");
+		} finally {
+			provider.stop(wapp); // never leak the cleaner timer if an assertion above fails
+		}
+	}
+
+	@Test
+	public void passivateShouldCancelCleanerTimerAndActivateShouldRestoreIt() throws Exception {
+		final SessionDesktopCacheProvider provider = new SessionDesktopCacheProvider();
+		final WebApp wapp = stubWebApp(newConfiguration());
+		provider.start(wapp);
+		try {
+			final Session sess = stubSession(wapp);
+			Set<Thread> before = timerThreads();
+			final SimpleDesktopCache cache = (SimpleDesktopCache) provider.getDesktopCache(sess);
+			final Desktop desktop = newPassivatingDesktop("zk6102-passivated", false);
+			cache.addDesktop(desktop);
+			Set<Thread> created = createdTimerThreads(before);
+			assertEquals(1, created.size());
+
+			for (int cycle = 0; cycle < 2; cycle++) {
+				provider.sessionWillPassivate(sess);
+				assertAllDead(created, "cleaner timer leaked after session passivation");
+				assertSame(desktop, cache.getDesktopIfAny("zk6102-passivated"),
+						"session passivation must keep desktops for serialization");
+
+				before = timerThreads();
+				provider.sessionDidActivate(sess);
+				created = createdTimerThreads(before);
+				assertEquals(1, created.size(),
+						"session activation should restore exactly one cleaner timer");
+			}
+
+			provider.stop(wapp);
+			assertAllDead(created, "cleaner timer of a reactivated session leaked after webapp stop");
+
+			before = timerThreads();
+			provider.sessionDidActivate(sess);
+			assertEquals(0, createdTimerThreads(before).size(),
+					"a stopped provider must not re-arm a cleaner timer from a late activation callback");
+		} finally {
+			provider.stop(wapp); // never leak the cleaner timer if an assertion above fails
+		}
+	}
+
+	@Test
+	public void sessionDestroyedShouldCancelCleanerTimer() throws Exception {
+		final SessionDesktopCacheProvider provider = new SessionDesktopCacheProvider();
+		final WebApp wapp = stubWebApp(newConfiguration());
+		provider.start(wapp);
+		try {
+			final Session sess = stubSession(wapp);
+			final Set<Thread> before = timerThreads();
+			provider.getDesktopCache(sess);
+			final Set<Thread> created = createdTimerThreads(before);
+			assertEquals(1, created.size());
+
+			provider.sessionDestroyed(sess);
+			assertAllDead(created, "cleaner timer leaked after session destroyed");
+		} finally {
+			provider.stop(wapp); // never leak the cleaner timer if an assertion above fails
+		}
+	}
+
+	@Test
+	public void cacheStopShouldCancelCleanerTimerWhenDesktopCleanupFails() throws Exception {
+		final Set<Thread> before = timerThreads();
+		final SimpleDesktopCache cache = new SimpleDesktopCache(newConfiguration());
+		final Set<Thread> created = createdTimerThreads(before);
+		assertFalse(created.isEmpty(), "SimpleDesktopCache should start a cleaner timer");
+
+		cache.addDesktop(newFailingDesktop("zk6102-cleanup-fails"));
+		assertThrows(RuntimeException.class, cache::stop);
+		assertAllDead(created, "cleaner timer leaked when desktop cleanup failed");
+	}
+
+	@Test
+	public void sessionWillPassivateShouldKeepCleanerWhenPassivationFails() throws Exception {
+		final Set<Thread> before = timerThreads();
+		final SimpleDesktopCache cache = new SimpleDesktopCache(newConfiguration());
+		final Set<Thread> created = createdTimerThreads(before);
+		assertFalse(created.isEmpty(), "SimpleDesktopCache should start a cleaner timer");
+
+		cache.addDesktop(newPassivatingDesktop("zk6102-passivation-fails", true));
+		try {
+			assertThrows(RuntimeException.class,
+					() -> cache.sessionWillPassivate(stubSession(stubWebApp(newConfiguration()))));
+			for (Thread timer : created)
+				assertTrue(timer.isAlive(),
+						"cleaner timer should remain alive if passivation fails before the cache is abandoned");
+		} finally {
+			try {
+				cache.stop();
+			} catch (RuntimeException ignored) {
+			}
+			assertAllDead(created, "cleaner timer leaked during test cleanup");
+		}
+	}
+
+	private static Configuration newConfiguration() {
+		final Configuration config = new Configuration();
+		config.setDesktopMaxInactiveInterval(600); // >= 0 starts a cleaner timer.
+		return config;
+	}
+
+	private static WebApp stubWebApp(final Configuration config) {
+		return (WebApp) Proxy.newProxyInstance(B104_ZK_6102Test.class.getClassLoader(),
+				new Class[] { WebApp.class }, new InvocationHandler() {
+					public Object invoke(Object proxy, Method method, Object[] args) {
+						if ("getConfiguration".equals(method.getName()))
+							return config;
+						return defaultValue(method.getReturnType());
+					}
+				});
+	}
+
+	private static Session stubSession(final WebApp wapp) {
+		final DesktopCache[] slot = new DesktopCache[1];
+		return (Session) Proxy.newProxyInstance(B104_ZK_6102Test.class.getClassLoader(),
+				new Class[] { Session.class, SessionCtrl.class }, new InvocationHandler() {
+					public Object invoke(Object proxy, Method method, Object[] args) {
+						final String name = method.getName();
+						if ("getDesktopCache".equals(name))
+							return slot[0];
+						if ("setDesktopCache".equals(name)) {
+							slot[0] = (DesktopCache) args[0];
+							return null;
+						}
+						if ("getWebApp".equals(name))
+							return wapp;
+						return defaultValue(method.getReturnType());
+					}
+				});
+	}
+
+	private static Desktop newDesktop(String id) {
+		return (Desktop) Proxy.newProxyInstance(B104_ZK_6102Test.class.getClassLoader(),
+				new Class[] { Desktop.class }, (proxy, method, args) -> {
+					if ("getId".equals(method.getName()))
+						return id;
+					return defaultValue(method.getReturnType());
+				});
+	}
+
+	private static Desktop newFailingDesktop(String id) {
+		return (Desktop) Proxy.newProxyInstance(B104_ZK_6102Test.class.getClassLoader(),
+				new Class[] { Desktop.class }, (proxy, method, args) -> {
+					if ("getId".equals(method.getName()))
+						return id;
+					if ("getSession".equals(method.getName()))
+						throw new RuntimeException("forced cleanup failure");
+					return defaultValue(method.getReturnType());
+				});
+	}
+
+	private static Desktop newPassivatingDesktop(String id, boolean failPassivation) {
+		return (Desktop) Proxy.newProxyInstance(B104_ZK_6102Test.class.getClassLoader(),
+				new Class[] { Desktop.class, DesktopCtrl.class }, (proxy, method, args) -> {
+					if ("getId".equals(method.getName()))
+						return id;
+					if ("sessionWillPassivate".equals(method.getName())) {
+						if (failPassivation)
+							throw new RuntimeException("forced passivation failure");
+						return null;
+					}
+					return defaultValue(method.getReturnType());
+				});
+	}
+
+	private static Set<Thread> createdTimerThreads(Set<Thread> before) {
+		final Set<Thread> created = timerThreads();
+		created.removeAll(before);
+		return created;
+	}
+
+	private static Set<Thread> timerThreads() {
+		final Set<Thread> threads = new HashSet<Thread>();
+		for (Thread t : Thread.getAllStackTraces().keySet())
+			if (t.isAlive() && t.getName().startsWith("Timer-"))
+				threads.add(t);
+		return threads;
+	}
+
+	private static void assertAllDead(Set<Thread> threads, String message) throws InterruptedException {
+		for (Thread timer : threads)
+			// Timer.cancel() ends the thread asynchronously; allow slack on slow CI.
+			assertTrue(waitUntilThreadGone(timer, 10000), message + ": " + timer.getName());
+	}
+
+	private static boolean waitUntilThreadGone(Thread thread, long timeoutMs) throws InterruptedException {
+		final long deadline = System.currentTimeMillis() + timeoutMs;
+		while (System.currentTimeMillis() < deadline) {
+			if (!thread.isAlive())
+				return true;
+			Thread.sleep(50);
+		}
+		return !thread.isAlive();
+	}
+
+	private static Object defaultValue(Class<?> type) {
+		if (type == boolean.class)
+			return Boolean.FALSE;
+		if (type == int.class)
+			return Integer.valueOf(0);
+		if (type == long.class)
+			return Long.valueOf(0L);
+		if (type == double.class)
+			return Double.valueOf(0);
+		if (type == float.class)
+			return Float.valueOf(0);
+		if (type == short.class)
+			return Short.valueOf((short) 0);
+		if (type == byte.class)
+			return Byte.valueOf((byte) 0);
+		if (type == char.class)
+			return Character.valueOf('\0');
+		return null;
+	}
+}


### PR DESCRIPTION
https://jenkins3.pxinternal.com/view/ZK%20Gradle%20Project%20Daily/job/ZK-Gradle-ZATS-Test/978/
* All failed tests passed locally, except `F104_ZK_4305_DaterangeAttributeTest.testPositionVerticalCenterPlacesPopupInViewport()`, to be fixed by #3597.