### PR TITLE
[WIP] ZK-6134: daterangebox: popup marks the 1st of each shown month as selected (phantom selection)

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -31,6 +31,7 @@ ZK 11.0.0
   ZK-5751: Combobox without an explicit itemRender mistakenly uses parent's template
   ZK-6136: Responsive Grid visible false column reappears
   ZK-6107: drag a panel in goldenlayout and it disappears
+  ZK-6134: daterangebox: popup marks the 1st of each shown month as selected (phantom selection)
 
 * Upgrade Notes
   + URLs.sanitizeURL now returns non-http/https URLs unchanged. Applications that call this public API directly should not rely on it to validate or reject container-owned resource URL formats such as jar/wsjar URLs without an entry separator.

--- a/zktest/src/main/webapp/test2/B110-ZK-6134.zul
+++ b/zktest/src/main/webapp/test2/B110-ZK-6134.zul
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+B110-ZK-6134.zul
+
+        Purpose:
+
+        Description:
+
+        History:
+                Wed Jul 22 15:35:59 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+-->
+<zk>
+    <label multiline="true">
+        Steps to reproduce:
+        1. Open the empty daterangebox popup below.
+        2. Open the seeded (2025-01-10 ~ 2025-01-15) daterangebox popup below.
+
+        The 1st of each shown month must NOT be marked selected.
+    </label>
+	<zscript><![CDATA[
+		java.util.Date b = new java.util.Date(125, 0, 10); // 2025-01-10
+		java.util.Date e = new java.util.Date(125, 0, 15); // 2025-01-15
+	]]></zscript>
+	<vlayout spacing="10px" hflex="1">
+		<label value="ZK-6134 - popup must not mark the 1st of a month as selected"/>
+		<daterangebox id="empty" format="yyyy-MM-dd"/>
+		<daterangebox id="seeded" format="yyyy-MM-dd" beginValue="${b}" endValue="${e}"/>
+	</vlayout>
+</zk>

--- a/zktest/src/main/webapp/test2/config.properties
+++ b/zktest/src/main/webapp/test2/config.properties
@@ -3291,6 +3291,7 @@ B90-ZK-4431.zul=A,E,Multislider
 ##zats##B110-ZK-6102.zul=A,E,SimpleDesktopCache,DesktopCacheProvider,Timer,thread,WebAppCleanup
 ##zats##B110-ZK-6107.zul=A,E,GoldenLayout,GoldenPanel
 ##zats##B110-ZK-5990.zul=A,E,Intbox,Doublebox,Longbox,Decimalbox,Spinner,Doublespinner,Constraint
+##zats##B110-ZK-6134.zul=A,E,Daterangebox
 
 ##
 # Features - 3.0.x version

--- a/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6134Test.java
+++ b/zktest/src/test/java/org/zkoss/zktest/zats/test2/B110_ZK_6134Test.java
@@ -1,0 +1,151 @@
+/* B110_ZK_6134Test.java
+
+        Purpose:
+
+        Description:
+
+        History:
+                Wed Jul 22 15:36:50 CST 2026, Created by peakerlee
+
+Copyright (C) 2026 Potix Corporation. All Rights Reserved.
+*/
+package org.zkoss.zktest.zats.test2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.zkoss.test.webdriver.WebDriverTestCase;
+
+public class B110_ZK_6134Test extends WebDriverTestCase {
+
+	private static final String POPUP = ".z-daterangebox-popup";
+
+	/** A panel's month anchor. DaterangePopup sets each Calendar's value to the
+	 *  1st purely to pick the displayed month, and CE marks that day
+	 *  z-calendar-selected — so the anchor must neither paint nor announce as a
+	 *  selection. The class stays (it is Calendar's keyboard cursor), which is
+	 *  why the paint has to be asserted rather than the class. */
+	private static final String ANCHOR = POPUP
+			+ " .z-calendar-cell.z-calendar-selected:not([class*=z-cell-range-])";
+
+	private long count(String selector) {
+		return Long.parseLong(getEval(
+				"document.querySelectorAll(\"" + selector + "\").length"));
+	}
+
+	private String backgroundOf(String selector) {
+		return getEval("(function () {"
+				+ "var e = document.querySelector(\"" + selector + "\");"
+				+ "return e ? getComputedStyle(e).backgroundColor : 'no-such-cell';"
+				+ "})()");
+	}
+
+	private boolean za11yActive() {
+		return "true".equals(getEval("!!window.za11y"));
+	}
+
+	private void openPopup(int boxIndex) {
+		click(jq(".z-daterangebox-button:eq(" + boxIndex + ")"));
+		waitResponse();
+		assertTrue(jq(POPUP + "-panels .z-calendar").exists());
+	}
+
+	/** Empty box: no range is set, so nothing in the popup may be announced as
+	 *  selected — in particular not the 1st of either displayed month. */
+	@Test
+	public void testEmptyBoxAnnouncesNoSelection() {
+		connect("/test2/B110-ZK-6134.zul");
+		waitResponse();
+		if (!za11yActive()) return; // NO_A11Y variant emits no aria state
+
+		openPopup(0);
+		assertEquals(0L, count(POPUP + " [aria-selected]"));
+		assertEquals(0L, count(POPUP + " [aria-current]"));
+	}
+
+	/** Seeded box (2025-01-10 .. 2025-01-15): the announcement must cover exactly
+	 *  the painted range — every highlighted day, not just its two ends — and the
+	 *  month anchor must be no part of it. */
+	@Test
+	public void testSeededBoxAnnouncesRangeOnly() {
+		connect("/test2/B110-ZK-6134.zul");
+		waitResponse();
+		if (!za11yActive()) return; // NO_A11Y variant emits no aria state
+
+		openPopup(1);
+		long ranged = count(POPUP + " [class*=z-cell-range-]");
+		assertTrue(ranged > 0, "the seeded range must paint some cells");
+		assertEquals(ranged,
+				count(POPUP + " [class*=z-cell-range-][aria-selected=true]"),
+				"every painted range cell must be announced as selected");
+		assertEquals(ranged, count(POPUP + " [aria-selected]"),
+				"only range cells may be announced as selected");
+		assertEquals(0L, count(ANCHOR + "[aria-selected]"),
+				"the month anchor must not be announced as selected");
+		assertEquals(0L, count(ANCHOR + "[aria-current]"),
+				"the month anchor must not be announced as the current date");
+	}
+
+	/** The ticket's visual claim. The fix keeps z-calendar-selected on the anchor
+	 *  and relies on the popup's LESS to neutralise it, so only a computed-style
+	 *  comparison can tell "hidden" from "painted". */
+	@Test
+	public void testAnchorCellPaintsLikePlainCell() {
+		connect("/test2/B110-ZK-6134.zul");
+		waitResponse();
+
+		openPopup(1);
+		String plain = backgroundOf(POPUP
+				+ " .z-calendar-cell:not(.z-calendar-selected):not(.z-calendar-outside)"
+				+ ":not([class*=z-cell-range-])");
+		assertEquals(plain, backgroundOf(ANCHOR),
+				"the 1st of the month must not paint as selected");
+		assertNotEquals(plain, backgroundOf(POPUP + " .z-cell-range-begin"),
+				"the range begin must still paint as highlighted");
+	}
+
+	/** An anchor that falls inside the hover-preview band must be painted by the
+	 *  band, not punched out of it: the suppression rule has to exclude the
+	 *  preview roles as well as the committed ones. */
+	@Test
+	public void testAnchorCellInsidePreviewBandPaintsLikeBand() {
+		connect("/test2/B110-ZK-6134.zul");
+		waitResponse();
+
+		openPopup(0);
+		// Stage a begin at the end of the first panel, then hover the 10th of the
+		// second so the preview band runs across that panel's 1st.
+		click(jq(POPUP + "-panels .z-calendar:eq(0) .z-calendar-cell:not(.z-calendar-outside):last"));
+		waitResponse();
+		getActions().moveToElement(toElement(jq(POPUP
+				+ "-panels .z-calendar:eq(1) .z-calendar-cell:not(.z-calendar-outside):eq(9)")))
+				.perform();
+		waitResponse();
+
+		String band = backgroundOf(POPUP
+				+ " .z-calendar-cell.z-cell-range-preview-mid:not(.z-calendar-selected)");
+		assertNotEquals("no-such-cell", band, "the hover preview must paint a band");
+		assertEquals(band, backgroundOf(POPUP
+						+ " .z-calendar-cell.z-calendar-selected.z-cell-range-preview-mid"),
+				"the month anchor must not leave a gap in the preview band");
+	}
+
+	/** The anchor must give the same hover feedback as any other day; the
+	 *  suppression rule out-specifies the plain :hover rule and has to restore it. */
+	@Test
+	public void testAnchorCellRespondsToHover() {
+		connect("/test2/B110-ZK-6134.zul");
+		waitResponse();
+
+		openPopup(1);
+		String resting = backgroundOf(ANCHOR);
+		getActions().moveToElement(toElement(jq(ANCHOR))).perform();
+		waitResponse();
+
+		assertEquals(1L, count(ANCHOR + ":hover"), "the hover must land on the anchor");
+		assertNotEquals(resting, backgroundOf(ANCHOR),
+				"the month anchor must light up under the mouse like any other day");
+	}
+}


### PR DESCRIPTION
Please merge this alongside https://github.com/zkoss/zkcml/pull/1365.